### PR TITLE
refactor(auth): deterministic allowlist list order

### DIFF
--- a/px-auth/src/infrastructure/yaml_allowlist_store.rs
+++ b/px-auth/src/infrastructure/yaml_allowlist_store.rs
@@ -3,7 +3,7 @@ use crate::domain::allowlist_store::AllowlistStore;
 use async_trait::async_trait;
 use px_errors::AppError;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 #[derive(Debug, Deserialize)]
@@ -11,8 +11,10 @@ struct AllowlistFile {
     entries: Vec<AllowlistEntry>,
 }
 
+/// `BTreeMap` keeps `list()` output in domain-sorted order so operator output
+/// (`px-cli allowlist list`) and audit diffs are reproducible across reloads.
 pub struct YamlAllowlistStore {
-    by_domain: HashMap<String, AllowlistEntry>,
+    by_domain: BTreeMap<String, AllowlistEntry>,
 }
 
 impl YamlAllowlistStore {
@@ -49,5 +51,46 @@ impl AllowlistStore for YamlAllowlistStore {
 
     async fn list(&self) -> Result<Vec<AllowlistEntry>, AppError> {
         Ok(self.by_domain.values().cloned().collect())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn entry(domain: &str) -> AllowlistEntry {
+        AllowlistEntry {
+            domain: domain.into(),
+            tos_reviewed: true,
+            justification: "test".into(),
+            handler: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn list_returns_entries_sorted_by_domain() {
+        let store = YamlAllowlistStore::from_entries(vec![
+            entry("zeta.example"),
+            entry("alpha.example"),
+            entry("mu.example"),
+        ]);
+        let listed: Vec<String> = store
+            .list()
+            .await
+            .expect("list")
+            .into_iter()
+            .map(|e| e.domain)
+            .collect();
+        assert_eq!(listed, vec!["alpha.example", "mu.example", "zeta.example"]);
+    }
+
+    #[tokio::test]
+    async fn lookup_finds_inserted_entry() {
+        let store = YamlAllowlistStore::from_entries(vec![entry("example.com")]);
+        let hit = store.lookup("example.com").await.expect("lookup");
+        assert_eq!(hit.map(|e| e.domain).as_deref(), Some("example.com"));
+        let miss = store.lookup("missing.example").await.expect("lookup");
+        assert!(miss.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Switch `YamlAllowlistStore` from `HashMap<String, AllowlistEntry>` to `BTreeMap`, so `list()` returns entries sorted by domain.
- Add unit tests covering the sort guarantee and the lookup path.

## Why
`HashMap` iteration order is non-deterministic, which makes `px-cli allowlist list` flaky and breaks reproducible audit diffs when the store is rebuilt. `BTreeMap` keeps `lookup()` semantics identical while giving operators a stable, sorted view.

## Test plan
- [x] `cargo test -p pxsolver-auth --lib yaml_allowlist_store` — 2/2 passing
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` clean against the lefthook ruleset (`-D warnings -D unwrap_used -D expect_used -D panic -D dbg_macro -D todo -D unimplemented`)
- [x] Lefthook pre-commit + pre-push hooks pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)