### PR TITLE
feat(server): drain in-flight solves on SIGTERM / Ctrl-C

### DIFF
--- a/px-server/src/main.rs
+++ b/px-server/src/main.rs
@@ -59,8 +59,48 @@ async fn main() -> Result<()> {
         .await
         .with_context(|| format!("bind {bind}"))?;
     tracing::info!(%bind, "px-server listening");
-    axum::serve(listener, app).await.context("axum serve")?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .context("axum serve")?;
+    tracing::info!("px-server stopped cleanly");
     Ok(())
+}
+
+/// Resolves when the process should begin a graceful shutdown.
+///
+/// Listens for SIGINT (Ctrl-C from a TTY) and, on Unix, SIGTERM (sent by
+/// systemd, Kubernetes, and `kill`). The first signal wins. Axum's
+/// `with_graceful_shutdown` then stops accepting new connections and lets
+/// in-flight `/v1/solve` requests finish before returning.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            tracing::warn!(error = %e, "ctrl_c signal handler install failed");
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        use tokio::signal::unix::{SignalKind, signal};
+        match signal(SignalKind::terminate()) {
+            Ok(mut s) => {
+                s.recv().await;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "SIGTERM handler install failed");
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => tracing::info!("SIGINT received, draining in-flight solves"),
+        _ = terminate => tracing::info!("SIGTERM received, draining in-flight solves"),
+    }
 }
 
 /// Collect the set of domains that should route through the Cloudflare


### PR DESCRIPTION
## Summary
Wire `axum::serve(...).with_graceful_shutdown(shutdown_signal())` so the server stops accepting new connections on the first of SIGINT or SIGTERM and lets the in-flight `/v1/solve` requests finish before the process exits.

- SIGINT (Ctrl-C from a TTY) and SIGTERM (systemd / Kubernetes / `kill`) both trigger the drain.
- SIGTERM branch is Unix-only; on non-Unix targets it becomes a pending future so SIGINT alone still wins.
- Signal-handler install failures are logged as warnings, not panics — worst case degrades to the previous "hard kill on close" behaviour.

## Why
Under the previous `axum::serve(...).await` form, sending SIGTERM (the systemd default `KillSignal`) aborted the runtime and dropped any in-flight `/v1/solve` requests mid-flight, which can leave the Chromium / Camoufox harvester pool in an inconsistent state (open browsers, zombie processes — exactly what MVP-AC-4 prohibits). A clean drain is also a prerequisite for the "weekly auto-soak" follow-up from ADR-0022 because the soak script can now restart the server between runs without ungraceful kills.

## Test plan
- [x] `cargo build -p px-server`
- [x] `cargo test -p px-server --lib` — all 6 unit tests pass
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` against the lefthook rule set
- [x] Lefthook pre-commit hooks pass locally (fmt, clippy, loc≤200, forbidden-patterns)
- [x] `px-server/src/main.rs` stays under the 200-LOC axum-best-practice rule (162 LOC)

## Notes for the reviewer
- The signal handler logs once per shutdown so operators can correlate the cause in journald.
- This does not touch the harvester pools directly; their `Drop` impls already kill child Chromium / geckodriver processes once the dispatchers are released, and a clean drain makes those Drops actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)