### PR TITLE
fix(server): cache hits preserve harvester user-agent

### DIFF
--- a/px-server/src/application/routing.rs
+++ b/px-server/src/application/routing.rs
@@ -71,15 +71,16 @@ impl SolveDispatcher for RoutingDispatcher {
                 outcome.status
             )));
         }
+        let user_agent = outcome.user_agent.clone().unwrap_or_default();
         let bundle = PxCookieBundle::new(
             outcome.cookies.set.clone(),
-            "px-harvester",
+            user_agent.clone(),
             SystemTime::now(),
             Duration::from_secs(600),
         );
         Ok(SolveOutput {
             bundle,
-            user_agent: outcome.user_agent.unwrap_or_default(),
+            user_agent,
             solve_ms: outcome.metrics.solve_ms,
             cache_hit: false,
             handler: outcome.handler,
@@ -161,6 +162,17 @@ mod tests {
             .await
             .expect("solve");
         assert_eq!(out.handler, "cloudflare");
+    }
+
+    /// Regression: the cookie bundle's `user_agent` must carry the real
+    /// harvester UA (so cache-hit replies preserve it), not a literal
+    /// placeholder string.
+    #[tokio::test]
+    async fn bundle_user_agent_matches_harvester() {
+        let d = RoutingDispatcher::new(Arc::new(StaticHandler { name: "perimeterx" }));
+        let out = d.solve("https://example.com/").await.expect("solve");
+        assert_eq!(out.user_agent, "ua");
+        assert_eq!(out.bundle.user_agent, "ua");
     }
 
     #[test]

--- a/px-server/src/application/solve_endpoint.rs
+++ b/px-server/src/application/solve_endpoint.rs
@@ -46,15 +46,16 @@ impl SolveDispatcher for PxSolveDispatcher {
                 self.handler_name, outcome.status
             )));
         }
+        let user_agent = outcome.user_agent.clone().unwrap_or_default();
         let bundle = PxCookieBundle::new(
             outcome.cookies.set.clone(),
-            "px-harvester",
+            user_agent.clone(),
             SystemTime::now(),
             Duration::from_secs(600),
         );
         Ok(SolveOutput {
             bundle,
-            user_agent: outcome.user_agent.unwrap_or_default(),
+            user_agent,
             solve_ms: outcome.metrics.solve_ms,
             cache_hit: false,
             handler: outcome.handler,


### PR DESCRIPTION
## Summary
The cookie bundle stored in the cache had its `user_agent` field hard-coded to the literal string `"px-harvester"`. On a cache hit, the response body's `user_agent` field was sourced from `bundle.user_agent` and therefore returned `"px-harvester"` instead of the real browser UA that the harvester actually used.

Fix: derive `user_agent` from `outcome.user_agent` once in both `PxSolveDispatcher::solve` and `RoutingDispatcher::solve`, then thread the same value into both the bundle and the `SolveOutput`.

## Why
Downstream clients that use the returned UA to replay requests (so the TLS ClientHello and the `User-Agent` header look consistent to PX/CF) were getting silently mis-routed on every cache-hit response: TLS impersonation said Firefox, header said `px-harvester`, server flagged the mismatch. Concretely this surfaced as a 403 from `pedidosya.com.ar/v4/shoplist/vendors` on the second and subsequent solve calls while the first call worked.

The first call worked because that path read `outcome.user_agent` directly into the response body and only masked the issue at the cache boundary.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` against the lefthook rule set
- [x] `cargo test -p px-server --lib routing` — 6/6 passing, including the new `bundle_user_agent_matches_harvester` regression test
- [x] Lefthook pre-commit + pre-push hooks pass locally (fmt, clippy, loc≤200, forbidden-patterns, tests)
- [x] Manual: against a running px-server, repeated `curl /v1/solve` for the same target — every response now returns the same Firefox UA the Camoufox harvester used, not `"px-harvester"`

## Notes for the reviewer
- Pure server-side change; no `px-cli`, `px-camoufox`, or `px-cloudflare` touched.
- The regression test lives next to the existing routing tests so it shares the `StaticHandler` fixture.
- This unblocks the consumer pattern of using `wreq` / curl-impersonate to replay the bundle on the same UA — without this fix, the cached UA always trips the server's UA/JA3 consistency check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)