### PR TITLE
feat(server): /v1/fetch endpoint backed by handler-owned browsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,10 +1549,12 @@ dependencies = [
  "pxsolver-core",
  "pxsolver-errors",
  "pxsolver-harvester",
+ "pxsolver-pipeline",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/px-camoufox/Cargo.toml
+++ b/px-camoufox/Cargo.toml
@@ -18,10 +18,12 @@ futures       = { workspace = true }
 px-core       = { workspace = true }
 px-errors     = { workspace = true }
 px-harvester  = { workspace = true }
+px-pipeline   = { workspace = true }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
 tokio         = { workspace = true, features = ["sync", "time", "macros", "rt", "rt-multi-thread", "process", "net", "io-util"] }
 tracing       = { workspace = true }
+url           = { workspace = true }
 
 [lib]
 name = "px_camoufox"

--- a/px-camoufox/src/infrastructure/camoufox_fetcher.rs
+++ b/px-camoufox/src/infrastructure/camoufox_fetcher.rs
@@ -1,0 +1,131 @@
+//! `Fetcher` impl on `CamoufoxPool`. Runs a single HTTP request from
+//! inside a fresh Camoufox session by navigating to the target URL's
+//! origin (so cookies/JS context are issued), then executing a
+//! `fetch()` from the page context. Captures status, headers, body.
+
+use crate::infrastructure::camoufox_pool::CamoufoxPool;
+use async_trait::async_trait;
+use fantoccini::ClientBuilder;
+use px_errors::AppError;
+use px_pipeline::{FetchRequest, FetchResponse, Fetcher};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+#[async_trait]
+impl Fetcher for CamoufoxPool {
+    async fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, AppError> {
+        let navigate_timeout = self.config.navigate_timeout;
+        let request_timeout = Duration::from_millis(req.timeout_ms);
+        self.with_session(None, async move |endpoint, caps| {
+            run_fetch(&endpoint, caps, &req, navigate_timeout, request_timeout).await
+        })
+        .await
+    }
+}
+
+async fn run_fetch(
+    endpoint: &str,
+    caps: Map<String, Value>,
+    req: &FetchRequest,
+    navigate_timeout: Duration,
+    request_timeout: Duration,
+) -> Result<FetchResponse, AppError> {
+    let started = Instant::now();
+    let client = ClientBuilder::native()
+        .capabilities(caps)
+        .connect(endpoint)
+        .await
+        .map_err(|e| AppError::InternalError(format!("webdriver connect: {e}")))?;
+
+    let origin = origin_of(&req.url)?;
+    let nav = client.goto(&origin);
+    if tokio::time::timeout(navigate_timeout, nav).await.is_err() {
+        let _ = client.close().await;
+        return Err(AppError::InternalError("navigate timeout".into()));
+    }
+    // Give Cloudflare / PerimeterX a beat to set their cookies.
+    sleep(Duration::from_millis(1_500)).await;
+
+    let script = build_fetch_script(req)?;
+    let exec = client.execute_async(&script, vec![]);
+    let raw = match tokio::time::timeout(request_timeout, exec).await {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
+            let _ = client.close().await;
+            return Err(AppError::InternalError(format!("fetch eval: {e}")));
+        }
+        Err(_) => {
+            let _ = client.close().await;
+            return Err(AppError::InternalError("fetch timeout".into()));
+        }
+    };
+    let _ = client.close().await;
+
+    let status = raw
+        .get("status")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| AppError::InternalError("fetch result missing status".into()))?
+        as u16;
+    let body = raw
+        .get("body")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let headers: HashMap<String, String> = raw
+        .get("headers")
+        .and_then(Value::as_object)
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(FetchResponse {
+        status,
+        headers,
+        body,
+        duration_ms: started.elapsed().as_millis() as u64,
+    })
+}
+
+fn origin_of(url: &str) -> Result<String, AppError> {
+    let parsed =
+        url::Url::parse(url).map_err(|e| AppError::BadRequest(format!("invalid url: {e}")))?;
+    Ok(format!(
+        "{}://{}{}",
+        parsed.scheme(),
+        parsed.host_str().unwrap_or(""),
+        parsed.port().map(|p| format!(":{p}")).unwrap_or_default()
+    ))
+}
+
+fn build_fetch_script(req: &FetchRequest) -> Result<String, AppError> {
+    let method = req.method().to_string();
+    let headers_json = serde_json::to_string(&req.headers)
+        .map_err(|e| AppError::InternalError(format!("encode headers: {e}")))?;
+    let body_json = serde_json::to_string(req.body.as_deref().unwrap_or(""))
+        .map_err(|e| AppError::InternalError(format!("encode body: {e}")))?;
+    let url_json = serde_json::to_string(&req.url)
+        .map_err(|e| AppError::InternalError(format!("encode url: {e}")))?;
+    let method_json = serde_json::to_string(&method)
+        .map_err(|e| AppError::InternalError(format!("encode method: {e}")))?;
+    Ok(format!(
+        r#"
+        const cb = arguments[arguments.length - 1];
+        const opts = {{ method: {method_json}, headers: {headers_json}, credentials: 'include' }};
+        const body = {body_json};
+        if (body !== '' && {method_json} !== 'GET') opts.body = body;
+        fetch({url_json}, opts)
+          .then(async (r) => {{
+            const text = await r.text();
+            const hdrs = {{}};
+            r.headers.forEach((v, k) => {{ hdrs[k] = v; }});
+            cb({{ status: r.status, headers: hdrs, body: text }});
+          }})
+          .catch((e) => cb({{ status: 0, headers: {{}}, body: String(e) }}));
+        "#
+    ))
+}

--- a/px-camoufox/src/infrastructure/camoufox_pool.rs
+++ b/px-camoufox/src/infrastructure/camoufox_pool.rs
@@ -1,19 +1,19 @@
 use crate::domain::config::CamoufoxConfig;
+use crate::infrastructure::caps::{build_capabilities, pick_free_port, wait_for_geckodriver};
 use async_trait::async_trait;
 use fantoccini::ClientBuilder;
 use px_errors::AppError;
 use px_harvester::{HarvestRequest, HarvestResult, HarvestedCookie, Harvester};
-use serde_json::{Map, Value, json};
+use serde_json::{Map, Value};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::net::TcpListener;
 use tokio::process::Command;
 use tokio::sync::Semaphore;
 use tokio::time::sleep;
 
 pub struct CamoufoxPool {
-    config: CamoufoxConfig,
-    permits: Arc<Semaphore>,
+    pub(crate) config: CamoufoxConfig,
+    pub(crate) permits: Arc<Semaphore>,
 }
 
 impl CamoufoxPool {
@@ -25,97 +25,23 @@ impl CamoufoxPool {
         Ok(Self { config, permits })
     }
 
-    async fn pick_free_port() -> Result<u16, AppError> {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .map_err(|e| AppError::InternalError(format!("bind ephemeral: {e}")))?;
-        let port = listener
-            .local_addr()
-            .map_err(|e| AppError::InternalError(format!("local_addr: {e}")))?
-            .port();
-        drop(listener);
-        Ok(port)
-    }
-
-    async fn wait_for_geckodriver(port: u16, timeout: Duration) -> Result<(), AppError> {
-        let deadline = tokio::time::Instant::now() + timeout;
-        loop {
-            if let Ok(resp) = get_status(port).await
-                && resp.contains("\"ready\":true")
-            {
-                return Ok(());
-            }
-            if tokio::time::Instant::now() >= deadline {
-                return Err(AppError::InternalError(format!(
-                    "geckodriver did not become ready on port {port} within {timeout:?}"
-                )));
-            }
-            sleep(Duration::from_millis(150)).await;
-        }
-    }
-
-    fn build_capabilities(&self, req: &HarvestRequest) -> Map<String, Value> {
-        let mut prefs = Map::new();
-        prefs.insert(
-            "intl.accept_languages".into(),
-            json!(self.config.locale.clone()),
-        );
-        prefs.insert("dom.webnotifications.enabled".into(), json!(false));
-        prefs.insert("media.peerconnection.enabled".into(), json!(false));
-
-        let mut firefox_options = Map::new();
-        let mut args: Vec<String> = Vec::new();
-        if self.config.headless {
-            args.push("-headless".into());
-        }
-        firefox_options.insert("args".into(), json!(args));
-        firefox_options.insert("prefs".into(), Value::Object(prefs));
-        firefox_options.insert(
-            "binary".into(),
-            json!(self.config.camoufox_bin.to_string_lossy()),
-        );
-
-        let mut caps = Map::new();
-        caps.insert("browserName".into(), json!("firefox"));
-        caps.insert("moz:firefoxOptions".into(), Value::Object(firefox_options));
-        if let Some(proxy_url) = &req.proxy {
-            caps.insert(
-                "proxy".into(),
-                json!({ "proxyType": "manual", "httpProxy": proxy_url, "sslProxy": proxy_url }),
-            );
-        }
-        caps
-    }
-}
-
-async fn get_status(port: u16) -> Result<String, AppError> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
-        .await
-        .map_err(|e| AppError::InternalError(format!("connect: {e}")))?;
-    let req =
-        format!("GET /status HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n");
-    stream
-        .write_all(req.as_bytes())
-        .await
-        .map_err(|e| AppError::InternalError(format!("write: {e}")))?;
-    let mut buf = Vec::with_capacity(2048);
-    stream
-        .read_to_end(&mut buf)
-        .await
-        .map_err(|e| AppError::InternalError(format!("read: {e}")))?;
-    Ok(String::from_utf8_lossy(&buf).to_string())
-}
-
-#[async_trait]
-impl Harvester for CamoufoxPool {
-    async fn harvest(&self, req: HarvestRequest) -> Result<HarvestResult, AppError> {
+    /// Spawn geckodriver + Camoufox, hand the resulting webdriver
+    /// endpoint to `body`, kill the child no matter what. Both the
+    /// `Harvester` and `Fetcher` impls share this lifecycle.
+    pub(crate) async fn with_session<F, R>(
+        &self,
+        proxy: Option<&str>,
+        body: F,
+    ) -> Result<R, AppError>
+    where
+        F: AsyncFnOnce(String, Map<String, Value>) -> Result<R, AppError>,
+    {
         let _permit = self
             .permits
             .acquire()
             .await
             .map_err(|e| AppError::InternalError(format!("semaphore: {e}")))?;
-        let port = Self::pick_free_port().await?;
+        let port = pick_free_port().await?;
         let mut child = Command::new(&self.config.geckodriver_bin)
             .arg("--port")
             .arg(port.to_string())
@@ -126,18 +52,28 @@ impl Harvester for CamoufoxPool {
             .kill_on_drop(true)
             .spawn()
             .map_err(|e| AppError::InternalError(format!("spawn geckodriver: {e}")))?;
-        Self::wait_for_geckodriver(port, Duration::from_secs(15)).await?;
-
-        let caps = self.build_capabilities(&req);
+        wait_for_geckodriver(port, Duration::from_secs(15)).await?;
+        let caps = build_capabilities(&self.config, proxy);
         let endpoint = format!("http://127.0.0.1:{port}");
-        let outcome = run_session(&endpoint, caps, &req, self.config.navigate_timeout).await;
-
+        let outcome = body(endpoint, caps).await;
         let _ = child.kill().await;
         outcome
     }
 }
 
-async fn run_session(
+#[async_trait]
+impl Harvester for CamoufoxPool {
+    async fn harvest(&self, req: HarvestRequest) -> Result<HarvestResult, AppError> {
+        let navigate_timeout = self.config.navigate_timeout;
+        let proxy = req.proxy.clone();
+        self.with_session(proxy.as_deref(), async move |endpoint, caps| {
+            harvest_session(&endpoint, caps, &req, navigate_timeout).await
+        })
+        .await
+    }
+}
+
+async fn harvest_session(
     endpoint: &str,
     caps: Map<String, Value>,
     req: &HarvestRequest,

--- a/px-camoufox/src/infrastructure/caps.rs
+++ b/px-camoufox/src/infrastructure/caps.rs
@@ -1,0 +1,90 @@
+//! Shared Camoufox webdriver helpers used by both `Harvester` and
+//! `Fetcher` implementations on `CamoufoxPool`.
+
+use crate::domain::config::CamoufoxConfig;
+use px_errors::AppError;
+use serde_json::{Map, Value, json};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::time::sleep;
+
+pub(crate) fn build_capabilities(
+    config: &CamoufoxConfig,
+    proxy: Option<&str>,
+) -> Map<String, Value> {
+    let mut prefs = Map::new();
+    prefs.insert("intl.accept_languages".into(), json!(config.locale.clone()));
+    prefs.insert("dom.webnotifications.enabled".into(), json!(false));
+    prefs.insert("media.peerconnection.enabled".into(), json!(false));
+
+    let mut firefox_options = Map::new();
+    let mut args: Vec<String> = Vec::new();
+    if config.headless {
+        args.push("-headless".into());
+    }
+    firefox_options.insert("args".into(), json!(args));
+    firefox_options.insert("prefs".into(), Value::Object(prefs));
+    firefox_options.insert(
+        "binary".into(),
+        json!(config.camoufox_bin.to_string_lossy()),
+    );
+
+    let mut caps = Map::new();
+    caps.insert("browserName".into(), json!("firefox"));
+    caps.insert("moz:firefoxOptions".into(), Value::Object(firefox_options));
+    if let Some(proxy_url) = proxy {
+        caps.insert(
+            "proxy".into(),
+            json!({ "proxyType": "manual", "httpProxy": proxy_url, "sslProxy": proxy_url }),
+        );
+    }
+    caps
+}
+
+pub(crate) async fn pick_free_port() -> Result<u16, AppError> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| AppError::InternalError(format!("bind ephemeral: {e}")))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| AppError::InternalError(format!("local_addr: {e}")))?
+        .port();
+    drop(listener);
+    Ok(port)
+}
+
+pub(crate) async fn wait_for_geckodriver(port: u16, timeout: Duration) -> Result<(), AppError> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Ok(resp) = get_status(port).await
+            && resp.contains("\"ready\":true")
+        {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(AppError::InternalError(format!(
+                "geckodriver did not become ready on port {port} within {timeout:?}"
+            )));
+        }
+        sleep(Duration::from_millis(150)).await;
+    }
+}
+
+pub(crate) async fn get_status(port: u16) -> Result<String, AppError> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .map_err(|e| AppError::InternalError(format!("connect: {e}")))?;
+    let req =
+        format!("GET /status HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(req.as_bytes())
+        .await
+        .map_err(|e| AppError::InternalError(format!("write: {e}")))?;
+    let mut buf = Vec::with_capacity(2048);
+    stream
+        .read_to_end(&mut buf)
+        .await
+        .map_err(|e| AppError::InternalError(format!("read: {e}")))?;
+    Ok(String::from_utf8_lossy(&buf).to_string())
+}

--- a/px-camoufox/src/infrastructure/mod.rs
+++ b/px-camoufox/src/infrastructure/mod.rs
@@ -1,1 +1,3 @@
+pub mod camoufox_fetcher;
 pub mod camoufox_pool;
+pub mod caps;

--- a/px-pipeline/src/domain/fetcher.rs
+++ b/px-pipeline/src/domain/fetcher.rs
@@ -1,0 +1,56 @@
+//! Port trait for executing an arbitrary HTTP request inside a
+//! handler-owned browser session. Built so the px-server `/v1/fetch`
+//! endpoint can proxy a single request through Camoufox / Chromium
+//! and bypass the JA3/UA mismatch that breaks bundle replay from
+//! downstream Rust HTTP clients (rustls, libcurl, etc).
+//!
+//! Lives next to `ChallengeHandler` because both ports are "things a
+//! browser-backed handler can do". Implementations live in their
+//! existing handler crates (`px-camoufox`, `px-harvester`).
+
+use async_trait::async_trait;
+use px_errors::AppError;
+use std::collections::HashMap;
+
+/// What to fetch. `method` is upper-case HTTP verb; missing → `GET`.
+#[derive(Debug, Clone)]
+pub struct FetchRequest {
+    pub url: String,
+    pub method: Option<String>,
+    pub headers: HashMap<String, String>,
+    pub body: Option<String>,
+    pub timeout_ms: u64,
+}
+
+impl FetchRequest {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            method: None,
+            headers: HashMap::new(),
+            body: None,
+            timeout_ms: 15_000,
+        }
+    }
+
+    pub fn method(&self) -> &str {
+        self.method.as_deref().unwrap_or("GET")
+    }
+}
+
+/// One response, captured verbatim from the browser-side `fetch`.
+#[derive(Debug, Clone)]
+pub struct FetchResponse {
+    pub status: u16,
+    pub headers: HashMap<String, String>,
+    pub body: String,
+    pub duration_ms: u64,
+}
+
+#[async_trait]
+pub trait Fetcher: Send + Sync {
+    /// Returns the response of running `req` from inside the
+    /// browser-managed session. Implementations must NOT cache the
+    /// result; this is a pass-through.
+    async fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, AppError>;
+}

--- a/px-pipeline/src/domain/mod.rs
+++ b/px-pipeline/src/domain/mod.rs
@@ -1,3 +1,4 @@
 pub mod challenge_handler;
+pub mod fetcher;
 pub mod handler_outcome;
 pub mod page_html;

--- a/px-pipeline/src/lib.rs
+++ b/px-pipeline/src/lib.rs
@@ -3,5 +3,6 @@ pub mod domain;
 
 pub use application::run_pipeline::Pipeline;
 pub use domain::challenge_handler::{ChallengeHandler, HandlerName};
+pub use domain::fetcher::{FetchRequest, FetchResponse, Fetcher};
 pub use domain::handler_outcome::{HandlerMetrics, HandlerOutcome, HandlerStatus};
 pub use domain::page_html::PageHtml;

--- a/px-server/src/application/fetch_endpoint.rs
+++ b/px-server/src/application/fetch_endpoint.rs
@@ -1,0 +1,127 @@
+//! `/v1/fetch` application layer.
+//!
+//! Mirrors `SolveDispatcher` in shape: routes inbound URL to one of N
+//! configured `Fetcher`s by domain, executes the request inside that
+//! handler's browser session, returns the captured response.
+//!
+//! The dispatcher does no caching — every fetch spawns its own
+//! browser session. That's expensive (~13s warm-up for Camoufox) but
+//! keeps the v1 API honest: callers know each request is fresh.
+
+use crate::application::solve_endpoint::domain_from_url;
+use async_trait::async_trait;
+use px_errors::AppError;
+use px_pipeline::{FetchRequest, FetchResponse, Fetcher};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+#[async_trait]
+pub trait FetchDispatcher: Send + Sync {
+    /// Resolve the fetcher for `req.url` and run the request through it.
+    /// Returns `(handler_name, response)` so the API layer can echo
+    /// which handler executed.
+    async fn dispatch(&self, req: FetchRequest) -> Result<(String, FetchResponse), AppError>;
+}
+
+#[derive(Clone)]
+pub struct RoutingFetchDispatcher {
+    default: Option<Arc<dyn Fetcher>>,
+    routes: BTreeMap<String, (String, Arc<dyn Fetcher>)>,
+}
+
+impl RoutingFetchDispatcher {
+    pub fn new(default: Option<Arc<dyn Fetcher>>) -> Self {
+        Self {
+            default,
+            routes: BTreeMap::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_route(
+        mut self,
+        domain: impl Into<String>,
+        name: impl Into<String>,
+        fetcher: Arc<dyn Fetcher>,
+    ) -> Self {
+        self.routes
+            .insert(domain.into().to_lowercase(), (name.into(), fetcher));
+        self
+    }
+
+    fn resolve(&self, host: &str) -> Option<&(String, Arc<dyn Fetcher>)> {
+        let host = host.to_lowercase();
+        for (domain, route) in &self.routes {
+            if host == *domain || host.ends_with(&format!(".{domain}")) {
+                return Some(route);
+            }
+        }
+        None
+    }
+}
+
+#[async_trait]
+impl FetchDispatcher for RoutingFetchDispatcher {
+    async fn dispatch(&self, req: FetchRequest) -> Result<(String, FetchResponse), AppError> {
+        let host = domain_from_url(&req.url)?;
+        if let Some((name, fetcher)) = self.resolve(&host) {
+            let resp = fetcher.fetch(req).await?;
+            return Ok((name.clone(), resp));
+        }
+        if let Some(default) = &self.default {
+            let resp = default.fetch(req).await?;
+            return Ok(("default".into(), resp));
+        }
+        Err(AppError::Conflict(format!(
+            "no fetcher configured for host {host}"
+        )))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    struct StaticFetcher {
+        tag: &'static str,
+    }
+
+    #[async_trait]
+    impl Fetcher for StaticFetcher {
+        async fn fetch(&self, _req: FetchRequest) -> Result<FetchResponse, AppError> {
+            Ok(FetchResponse {
+                status: 200,
+                headers: HashMap::new(),
+                body: self.tag.to_string(),
+                duration_ms: 0,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn routes_match_by_dns_suffix() {
+        let d = RoutingFetchDispatcher::new(None).with_route(
+            "pedidosya.com.ar",
+            "cloudflare",
+            Arc::new(StaticFetcher { tag: "cf" }),
+        );
+        let (name, resp) = d
+            .dispatch(FetchRequest::new("https://www.pedidosya.com.ar/x"))
+            .await
+            .expect("dispatch");
+        assert_eq!(name, "cloudflare");
+        assert_eq!(resp.body, "cf");
+    }
+
+    #[tokio::test]
+    async fn returns_conflict_when_no_route_and_no_default() {
+        let d = RoutingFetchDispatcher::new(None);
+        let err = d
+            .dispatch(FetchRequest::new("https://example.com/"))
+            .await
+            .expect_err("should fail");
+        assert!(matches!(err, AppError::Conflict(_)));
+    }
+}

--- a/px-server/src/application/mod.rs
+++ b/px-server/src/application/mod.rs
@@ -1,2 +1,3 @@
+pub mod fetch_endpoint;
 pub mod routing;
 pub mod solve_endpoint;

--- a/px-server/src/infrastructure/bootstrap/app_state.rs
+++ b/px-server/src/infrastructure/bootstrap/app_state.rs
@@ -1,3 +1,4 @@
+use crate::application::fetch_endpoint::FetchDispatcher;
 use crate::application::solve_endpoint::SolveDispatcher;
 use crate::infrastructure::bootstrap::server_metrics::ServerMetrics;
 use px_auth::{AuditSink, CheckAllowlist, VerifyKey};
@@ -9,6 +10,7 @@ pub struct AppState {
     pub verify_key: Arc<VerifyKey>,
     pub check_allowlist: Arc<CheckAllowlist>,
     pub dispatcher: Arc<dyn SolveDispatcher>,
+    pub fetch_dispatcher: Arc<dyn FetchDispatcher>,
     pub cache: Arc<dyn CookieCache>,
     pub audit: Arc<dyn AuditSink>,
     pub build_sha: &'static str,
@@ -20,6 +22,7 @@ pub struct AppStateConfig {
     pub verify_key: Arc<VerifyKey>,
     pub check_allowlist: Arc<CheckAllowlist>,
     pub dispatcher: Arc<dyn SolveDispatcher>,
+    pub fetch_dispatcher: Arc<dyn FetchDispatcher>,
     pub cache: Arc<dyn CookieCache>,
     pub audit: Arc<dyn AuditSink>,
     pub build_sha: &'static str,
@@ -35,6 +38,7 @@ impl AppState {
             verify_key: cfg.verify_key,
             check_allowlist: cfg.check_allowlist,
             dispatcher: cfg.dispatcher,
+            fetch_dispatcher: cfg.fetch_dispatcher,
             cache: cfg.cache,
             audit: cfg.audit,
             build_sha: cfg.build_sha,

--- a/px-server/src/infrastructure/bootstrap/dispatchers.rs
+++ b/px-server/src/infrastructure/bootstrap/dispatchers.rs
@@ -1,0 +1,65 @@
+//! Builds the `SolveDispatcher` and the `FetchDispatcher` that the
+//! `/v1/solve` and `/v1/fetch` HTTP handlers depend on.
+//!
+//! Both dispatchers share the same `CamoufoxPool` (when one is built)
+//! so `harvest` and `fetch` against a Cloudflare-fronted target reuse
+//! the same browser config. The pool is wrapped in `Arc` and handed to
+//! the role-specific traits (`Harvester` for solve, `Fetcher` for fetch).
+
+use crate::application::fetch_endpoint::{FetchDispatcher, RoutingFetchDispatcher};
+use crate::application::routing::RoutingDispatcher;
+use crate::application::solve_endpoint::{PxSolveDispatcher, SolveDispatcher};
+use anyhow::{Context, Result};
+use px_camoufox::{CamoufoxConfig, CamoufoxPool};
+use px_cloudflare::CloudflareHandler;
+use px_harvester::Harvester;
+use px_pipeline::{ChallengeHandler, Fetcher};
+use std::sync::Arc;
+
+pub struct Dispatchers {
+    pub solve: Arc<dyn SolveDispatcher>,
+    pub fetch: Arc<dyn FetchDispatcher>,
+}
+
+pub fn build_dispatchers(
+    default_handler: Arc<dyn ChallengeHandler>,
+    cf_domains: Vec<String>,
+) -> Result<Dispatchers> {
+    if cf_domains.is_empty() {
+        return Ok(Dispatchers {
+            solve: Arc::new(PxSolveDispatcher::new(default_handler)),
+            fetch: Arc::new(RoutingFetchDispatcher::new(None)),
+        });
+    }
+
+    let cfg = CamoufoxConfig::from_env();
+    if let Err(e) = cfg.validate() {
+        tracing::warn!(
+            error = %e,
+            domains = ?cf_domains,
+            "Cloudflare routes configured but Camoufox unavailable; falling back to Chromium-only solve dispatcher (no /v1/fetch)"
+        );
+        return Ok(Dispatchers {
+            solve: Arc::new(PxSolveDispatcher::new(default_handler)),
+            fetch: Arc::new(RoutingFetchDispatcher::new(None)),
+        });
+    }
+
+    let pool = Arc::new(CamoufoxPool::new(cfg).context("build CamoufoxPool")?);
+    let harvester: Arc<dyn Harvester> = Arc::clone(&pool) as Arc<dyn Harvester>;
+    let fetcher: Arc<dyn Fetcher> = Arc::clone(&pool) as Arc<dyn Fetcher>;
+    let cf_handler: Arc<dyn ChallengeHandler> =
+        Arc::new(CloudflareHandler::with_harvester(harvester));
+
+    let mut solve_router = RoutingDispatcher::new(default_handler);
+    let mut fetch_router = RoutingFetchDispatcher::new(None);
+    for d in &cf_domains {
+        solve_router = solve_router.with_route(d.clone(), Arc::clone(&cf_handler));
+        fetch_router = fetch_router.with_route(d.clone(), "cloudflare", Arc::clone(&fetcher));
+    }
+    tracing::info!(domains = ?cf_domains, "Camoufox routing enabled (solve + fetch)");
+    Ok(Dispatchers {
+        solve: Arc::new(solve_router),
+        fetch: Arc::new(fetch_router),
+    })
+}

--- a/px-server/src/infrastructure/bootstrap/mod.rs
+++ b/px-server/src/infrastructure/bootstrap/mod.rs
@@ -1,3 +1,4 @@
 pub mod app_state;
+pub mod dispatchers;
 pub mod router;
 pub mod server_metrics;

--- a/px-server/src/infrastructure/bootstrap/router.rs
+++ b/px-server/src/infrastructure/bootstrap/router.rs
@@ -1,11 +1,12 @@
 use crate::infrastructure::bootstrap::app_state::AppState;
-use crate::infrastructure::http::handlers::{health, metrics, solve};
+use crate::infrastructure::http::handlers::{fetch, health, metrics, solve};
 use axum::Router;
 use axum::routing::{get, post};
 
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/v1/solve", post(solve::handle))
+        .route("/v1/fetch", post(fetch::handle))
         .route("/v1/health", get(health::handle))
         .route("/v1/metrics", get(metrics::handle))
         .with_state(state)

--- a/px-server/src/infrastructure/http/dto.rs
+++ b/px-server/src/infrastructure/http/dto.rs
@@ -1,9 +1,32 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct SolveRequestDto {
     pub url: String,
     pub proxy: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FetchRequestDto {
+    pub url: String,
+    #[serde(default)]
+    pub method: Option<String>,
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FetchResponseDto {
+    pub status: u16,
+    pub headers: HashMap<String, String>,
+    pub body: String,
+    pub duration_ms: u64,
+    pub handler: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/px-server/src/infrastructure/http/handlers/fetch.rs
+++ b/px-server/src/infrastructure/http/handlers/fetch.rs
@@ -1,0 +1,116 @@
+use crate::application::solve_endpoint::domain_from_url;
+use crate::infrastructure::bootstrap::app_state::AppState;
+use crate::infrastructure::http::dto::{FetchRequestDto, FetchResponseDto};
+use axum::Json;
+use axum::extract::State;
+use axum::http::HeaderMap;
+use px_auth::{AuditEvent, AuditOutcome};
+use px_errors::AppError;
+use px_pipeline::FetchRequest;
+use px_types::SingleResponse;
+use std::sync::atomic::Ordering;
+use std::time::{Instant, SystemTime};
+
+pub async fn handle(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(payload): Json<FetchRequestDto>,
+) -> Result<Json<SingleResponse<FetchResponseDto>>, AppError> {
+    let started = Instant::now();
+    let key_id = verify_authorization(&state, &headers)
+        .await
+        .inspect_err(|_| {
+            state.metrics.auth_denied.fetch_add(1, Ordering::Relaxed);
+        })?;
+    let domain = domain_from_url(&payload.url)?;
+    state
+        .check_allowlist
+        .execute(&domain)
+        .await
+        .inspect_err(|_| {
+            state
+                .metrics
+                .allowlist_denied
+                .fetch_add(1, Ordering::Relaxed);
+        })?;
+
+    let req = FetchRequest {
+        url: payload.url.clone(),
+        method: payload.method,
+        headers: payload.headers,
+        body: payload.body,
+        timeout_ms: payload.timeout_ms.unwrap_or(15_000),
+    };
+    let dispatched = state.fetch_dispatcher.dispatch(req).await;
+    let (handler_name, response) = match dispatched {
+        Ok(v) => v,
+        Err(e) => {
+            record_audit(
+                &state,
+                key_id.clone(),
+                domain.clone(),
+                started,
+                AuditOutcome::HandlerFailed,
+                None,
+            )
+            .await?;
+            return Err(e);
+        }
+    };
+    record_audit(
+        &state,
+        key_id,
+        domain,
+        started,
+        AuditOutcome::Solved,
+        Some(handler_name.clone()),
+    )
+    .await?;
+    let body = FetchResponseDto {
+        status: response.status,
+        headers: response.headers,
+        body: response.body,
+        duration_ms: response.duration_ms,
+        handler: handler_name,
+    };
+    Ok(Json(SingleResponse::new(body, "fetched")))
+}
+
+async fn record_audit(
+    state: &AppState,
+    key_id: String,
+    target_domain: String,
+    started: Instant,
+    outcome: AuditOutcome,
+    handler: Option<String>,
+) -> Result<(), AppError> {
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    let now_unix = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let event = AuditEvent {
+        timestamp_unix: now_unix,
+        key_id,
+        target_domain,
+        outcome,
+        latency_ms: elapsed_ms,
+        handler,
+    };
+    state.audit.record(&event).await
+}
+
+async fn verify_authorization(state: &AppState, headers: &HeaderMap) -> Result<String, AppError> {
+    let raw = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| AppError::Unauthorized("missing Authorization header".into()))?;
+    let token = raw.strip_prefix("Bearer ").ok_or_else(|| {
+        AppError::Unauthorized("Authorization must be 'Bearer <id>:<secret>'".into())
+    })?;
+    let (id, secret) = token
+        .split_once(':')
+        .ok_or_else(|| AppError::Unauthorized("Bearer token must be 'id:secret'".into()))?;
+    state.verify_key.execute(id, secret).await?;
+    Ok(id.to_string())
+}

--- a/px-server/src/infrastructure/http/handlers/mod.rs
+++ b/px-server/src/infrastructure/http/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod fetch;
 pub mod health;
 pub mod metrics;
 pub mod solve;

--- a/px-server/src/main.rs
+++ b/px-server/src/main.rs
@@ -3,13 +3,11 @@ use px_auth::{
     AllowlistStore, CheckAllowlist, StdoutAuditSink, VerifyKey, YamlAllowlistStore, YamlKeyStore,
 };
 use px_cache::InMemoryCookieCache;
-use px_camoufox::{CamoufoxConfig, CamoufoxPool};
-use px_cloudflare::CloudflareHandler;
 use px_harvester::{ChromiumoxidePool, Harvester, PoolConfig};
 use px_perimeterx::PerimeterxHandler;
 use px_pipeline::ChallengeHandler;
-use px_server::application::routing::{RoutingDispatcher, parse_camoufox_domains};
-use px_server::application::solve_endpoint::{PxSolveDispatcher, SolveDispatcher};
+use px_server::application::routing::parse_camoufox_domains;
+use px_server::infrastructure::bootstrap::dispatchers::build_dispatchers;
 use px_server::{AppState, AppStateConfig, build_router};
 use std::collections::BTreeSet;
 use std::env;
@@ -43,12 +41,13 @@ async fn main() -> Result<()> {
         Arc::new(PerimeterxHandler::new(Arc::clone(&harvester)));
 
     let cf_domains = resolve_cf_domains(allowlist_store.as_ref()).await?;
-    let dispatcher = build_dispatcher(px_handler, cf_domains)?;
+    let dispatchers = build_dispatchers(px_handler, cf_domains)?;
 
     let state = AppState::new(AppStateConfig {
         verify_key: Arc::new(VerifyKey::new(Arc::new(key_store))),
         check_allowlist: Arc::new(CheckAllowlist::new(Arc::clone(&allowlist_store))),
-        dispatcher,
+        dispatcher: dispatchers.solve,
+        fetch_dispatcher: dispatchers.fetch,
         cache: Arc::new(InMemoryCookieCache::new()),
         audit: Arc::new(StdoutAuditSink::new()),
         build_sha: env!("CARGO_PKG_VERSION"),
@@ -122,41 +121,4 @@ async fn resolve_cf_domains(store: &dyn AllowlistStore) -> Result<Vec<String>> {
         set.insert(d);
     }
     Ok(set.into_iter().collect())
-}
-
-/// Build the SolveDispatcher. If `cf_domains` is non-empty and both the
-/// Camoufox and geckodriver binaries validate at the configured paths,
-/// returns a RoutingDispatcher routing those domains to a CloudflareHandler
-/// backed by a CamoufoxPool. Otherwise returns the default Chromium-only
-/// dispatcher (logging a warn if domains were requested but binaries were
-/// unavailable).
-fn build_dispatcher(
-    default_handler: Arc<dyn ChallengeHandler>,
-    cf_domains: Vec<String>,
-) -> Result<Arc<dyn SolveDispatcher>> {
-    if cf_domains.is_empty() {
-        return Ok(Arc::new(PxSolveDispatcher::new(default_handler)));
-    }
-
-    let cfg = CamoufoxConfig::from_env();
-    if let Err(e) = cfg.validate() {
-        tracing::warn!(
-            error = %e,
-            domains = ?cf_domains,
-            "Cloudflare routes configured but Camoufox unavailable; falling back to Chromium-only dispatcher"
-        );
-        return Ok(Arc::new(PxSolveDispatcher::new(default_handler)));
-    }
-
-    let pool = CamoufoxPool::new(cfg).context("build CamoufoxPool")?;
-    let camoufox: Arc<dyn Harvester> = Arc::new(pool);
-    let cf_handler: Arc<dyn ChallengeHandler> =
-        Arc::new(CloudflareHandler::with_harvester(camoufox));
-
-    let mut router = RoutingDispatcher::new(default_handler);
-    for d in &cf_domains {
-        router = router.with_route(d.clone(), Arc::clone(&cf_handler));
-    }
-    tracing::info!(domains = ?cf_domains, "Camoufox routing enabled");
-    Ok(Arc::new(router))
 }

--- a/px-server/tests/canary_cf.rs
+++ b/px-server/tests/canary_cf.rs
@@ -97,6 +97,9 @@ async fn pedidosya_solve_via_camoufox_path() {
         verify_key: Arc::new(VerifyKey::new(key_store)),
         check_allowlist: Arc::new(CheckAllowlist::new(allowlist_store)),
         dispatcher,
+        fetch_dispatcher: Arc::new(
+            px_server::application::fetch_endpoint::RoutingFetchDispatcher::new(None),
+        ),
         cache: Arc::new(InMemoryCookieCache::new()),
         audit,
         build_sha: "canary-cf",

--- a/px-server/tests/common/mod.rs
+++ b/px-server/tests/common/mod.rs
@@ -13,6 +13,7 @@ use px_auth::{
 use px_cache::InMemoryCookieCache;
 use px_core::NamedCookie;
 use px_errors::AppError;
+use px_server::application::fetch_endpoint::RoutingFetchDispatcher;
 use px_server::application::solve_endpoint::{SolveDispatcher, SolveOutput};
 use px_server::{AppState, AppStateConfig};
 use std::sync::Arc;
@@ -92,6 +93,7 @@ pub fn build_state_with_dispatcher(
         verify_key: Arc::new(VerifyKey::new(key_store)),
         check_allowlist: Arc::new(CheckAllowlist::new(allowlist_store)),
         dispatcher,
+        fetch_dispatcher: Arc::new(RoutingFetchDispatcher::new(None)),
         cache: Arc::new(InMemoryCookieCache::new()),
         audit,
         build_sha: "test",


### PR DESCRIPTION
## Summary
Adds a generic `POST /v1/fetch` proxy that runs a single HTTP request from inside the same browser session a Cloudflare/PerimeterX handler would have spawned for `/v1/solve`. Solves the JA3/UA cliff downstream Rust clients hit when replaying the cookie bundle: the response comes from the real Firefox so cookies, TLS ClientHello, and User-Agent are all consistent to the upstream WAF.

## What's wired
- New `Fetcher` port trait in `px-pipeline` next to `ChallengeHandler`, with `FetchRequest` / `FetchResponse` value types.
- `CamoufoxPool` now implements `Fetcher` (in addition to `Harvester`). The new impl navigates to the target URL's origin, waits 1.5s for CF/PX to issue cookies, then executes a `fetch()` from the page context via `execute_async`, capturing status / headers / body.
- Both Harvester and Fetcher share `CamoufoxPool::with_session`, extracted alongside the shared `caps` helpers (`pick_free_port`, `wait_for_geckodriver`, `build_capabilities`, `get_status`).
- `RoutingFetchDispatcher` mirrors `RoutingDispatcher`: same DNS-suffix routing, no caching (each fetch spawns a fresh browser), per-route handler name echoed in the response so the API caller knows which path executed.
- New `POST /v1/fetch` axum route. Same Bearer-token auth and per-domain allowlist checks as `/v1/solve`, same `record_audit` log shape.
- New DTOs `FetchRequestDto` / `FetchResponseDto`.
- `AppState`/`AppStateConfig` gain a `fetch_dispatcher` field. Both dispatchers are now built together in `bootstrap::dispatchers::build_dispatchers`, which keeps `main.rs` under the 200-LOC rule and lets the shared `CamoufoxPool` back both the `Harvester` (solve) and `Fetcher` (fetch) traits via `Arc::clone`.
- Existing tests updated to populate the new field with an empty `RoutingFetchDispatcher::new(None)`.

## What's not wired
- No `Fetcher` impl on the Chromium pool yet — only CF-routed domains get `/v1/fetch`. Allowlisted-but-PX-only domains return `Conflict("no fetcher configured for host ...")`. A follow-up can add `ChromiumoxidePool: impl Fetcher`.
- No browser session reuse — every fetch spawns geckodriver + Camoufox + tears them down. That's ~13s on a warm machine. Pooling is an ADR-level decision; this PR keeps the v1 surface honest.

## Why
Downstream Rust HTTP clients (rustls, libcurl, wreq with stock Firefox emulation) can't replay a `cf_clearance` cookie because Cloudflare's Bot Management binds the cookie to the TLS ClientHello of the browser that earned it. Camoufox's ClientHello is custom; no off-the-shelf Rust crate matches it exactly. The cleanest fix is to do the actual fetch *inside* the Camoufox session and return the response to the API caller, which is what `/v1/fetch` does.

This unblocks consumers like the pedidosya scraper that want to drive paginated XHRs against CF-fronted endpoints without inheriting the WAF arms race.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` against the lefthook rule set (`-D warnings -D unwrap_used -D expect_used -D panic -D dbg_macro -D todo -D unimplemented`)
- [x] `cargo test --workspace --lib` — existing tests pass plus two new ones (`routes_match_by_dns_suffix`, `returns_conflict_when_no_route_and_no_default`) in `fetch_endpoint::tests`
- [x] `cargo test -p px-server` — `server.rs` integration tests still pass after the `AppStateConfig` field addition
- [x] Lefthook pre-commit + pre-push hooks green locally (fmt, clippy, loc-200, forbidden-patterns, tests)
- [ ] Manual canary against `pedidosya.com.ar` deferred to a follow-up commit once a downstream consumer (the pedidosya scraper) exercises the endpoint end-to-end

## Files
```
px-pipeline/src/domain/fetcher.rs           NEW  Fetcher trait + value types
px-camoufox/src/infrastructure/caps.rs      NEW  Shared geckodriver helpers
px-camoufox/src/infrastructure/camoufox_pool.rs  with_session helper extracted
px-camoufox/src/infrastructure/camoufox_fetcher.rs  NEW  Fetcher impl
px-server/src/application/fetch_endpoint.rs       NEW  FetchDispatcher + tests
px-server/src/infrastructure/bootstrap/dispatchers.rs  NEW  build_dispatchers
px-server/src/infrastructure/http/handlers/fetch.rs    NEW  HTTP handler
px-server/src/infrastructure/http/dto.rs              FetchRequestDto/Response
px-server/src/infrastructure/bootstrap/{app_state,router}.rs  wire fetch_dispatcher
px-server/src/main.rs                                 collapse build_dispatcher() into bootstrap::dispatchers
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)