### PR TITLE
feat(camoufox): per-domain persistent session for /v1/fetch

### DIFF
--- a/px-camoufox/src/infrastructure/camoufox_fetcher.rs
+++ b/px-camoufox/src/infrastructure/camoufox_fetcher.rs
@@ -1,88 +1,84 @@
-//! `Fetcher` impl on `CamoufoxPool`. Runs a single HTTP request from
-//! inside a fresh Camoufox session by navigating to the target URL's
-//! origin (so cookies/JS context are issued), then executing a
-//! `fetch()` from the page context. Captures status, headers, body.
+//! `Fetcher` impl on `CamoufoxPool`. Reuses a per-domain persistent
+//! Camoufox session so the geckodriver/browser cold-start (~13s)
+//! happens once per domain, PerimeterX sees a coherent browser
+//! session instead of a stream of throwaway ones, and `cf_clearance`
+//! issued during the first navigation is reused.
+//!
+//! GET routes through `navigate_and_read` so the browser handles
+//! interactive Cloudflare challenges; POST routes through
+//! `in_page_fetch` because webdriver navigation can't carry a body.
+//! See `fetch_strategies` for both.
 
 use crate::infrastructure::camoufox_pool::CamoufoxPool;
+use crate::infrastructure::fetch_strategies::{
+    in_page_fetch, navigate_and_read, navigate_with_wait,
+};
+use crate::infrastructure::session::PersistentSession;
 use async_trait::async_trait;
-use fantoccini::ClientBuilder;
 use px_errors::AppError;
 use px_pipeline::{FetchRequest, FetchResponse, Fetcher};
-use serde_json::{Map, Value};
-use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::time::sleep;
 
 #[async_trait]
 impl Fetcher for CamoufoxPool {
     async fn fetch(&self, req: FetchRequest) -> Result<FetchResponse, AppError> {
+        let domain = domain_of(&req.url)?;
+        let session = self.sessions.acquire(&domain).await?;
         let navigate_timeout = self.config.navigate_timeout;
         let request_timeout = Duration::from_millis(req.timeout_ms);
-        self.with_session(None, async move |endpoint, caps| {
-            run_fetch(&endpoint, caps, &req, navigate_timeout, request_timeout).await
-        })
-        .await
+        run_through_session(session, req, navigate_timeout, request_timeout).await
     }
 }
 
-async fn run_fetch(
-    endpoint: &str,
-    caps: Map<String, Value>,
-    req: &FetchRequest,
+async fn run_through_session(
+    session: Arc<PersistentSession>,
+    req: FetchRequest,
     navigate_timeout: Duration,
     request_timeout: Duration,
 ) -> Result<FetchResponse, AppError> {
     let started = Instant::now();
-    let client = ClientBuilder::native()
-        .capabilities(caps)
-        .connect(endpoint)
+    let mut inner = session.inner.lock().await;
+
+    // Warm the browser once per session: load the origin so Cloudflare's
+    // managed challenge JS runs and `cf_clearance` lands in the jar.
+    if !inner.warmed {
+        let origin = origin_of(&req.url)?;
+        if let Err(e) = navigate_with_wait(
+            &inner.client,
+            &origin,
+            navigate_timeout,
+            Duration::from_millis(4_000),
+        )
         .await
-        .map_err(|e| AppError::InternalError(format!("webdriver connect: {e}")))?;
-
-    let origin = origin_of(&req.url)?;
-    let nav = client.goto(&origin);
-    if tokio::time::timeout(navigate_timeout, nav).await.is_err() {
-        let _ = client.close().await;
-        return Err(AppError::InternalError("navigate timeout".into()));
+        {
+            tracing::warn!(error = %e, "session warmup failed; downstream will likely 403");
+        } else {
+            inner.warmed = true;
+        }
     }
-    // Give Cloudflare / PerimeterX a beat to set their cookies.
-    sleep(Duration::from_millis(1_500)).await;
+    if let Some(referer) = referer_header(&req)
+        && !referer.is_empty()
+    {
+        let _ = navigate_with_wait(
+            &inner.client,
+            &referer,
+            navigate_timeout,
+            Duration::from_millis(2_000),
+        )
+        .await;
+    }
 
-    let script = build_fetch_script(req)?;
-    let exec = client.execute_async(&script, vec![]);
-    let raw = match tokio::time::timeout(request_timeout, exec).await {
-        Ok(Ok(v)) => v,
-        Ok(Err(e)) => {
-            let _ = client.close().await;
-            return Err(AppError::InternalError(format!("fetch eval: {e}")));
-        }
-        Err(_) => {
-            let _ = client.close().await;
-            return Err(AppError::InternalError("fetch timeout".into()));
-        }
+    let outcome = if req.method().eq_ignore_ascii_case("GET") {
+        navigate_and_read(&inner.client, &req, navigate_timeout).await
+    } else {
+        in_page_fetch(&inner.client, &req, request_timeout).await
     };
-    let _ = client.close().await;
+    inner.last_used = Instant::now();
+    inner.fetch_count = inner.fetch_count.saturating_add(1);
+    drop(inner);
 
-    let status = raw
-        .get("status")
-        .and_then(Value::as_u64)
-        .ok_or_else(|| AppError::InternalError("fetch result missing status".into()))?
-        as u16;
-    let body = raw
-        .get("body")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
-    let headers: HashMap<String, String> = raw
-        .get("headers")
-        .and_then(Value::as_object)
-        .map(|m| {
-            m.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                .collect()
-        })
-        .unwrap_or_default();
-
+    let (status, headers, body) = outcome?;
     Ok(FetchResponse {
         status,
         headers,
@@ -102,30 +98,15 @@ fn origin_of(url: &str) -> Result<String, AppError> {
     ))
 }
 
-fn build_fetch_script(req: &FetchRequest) -> Result<String, AppError> {
-    let method = req.method().to_string();
-    let headers_json = serde_json::to_string(&req.headers)
-        .map_err(|e| AppError::InternalError(format!("encode headers: {e}")))?;
-    let body_json = serde_json::to_string(req.body.as_deref().unwrap_or(""))
-        .map_err(|e| AppError::InternalError(format!("encode body: {e}")))?;
-    let url_json = serde_json::to_string(&req.url)
-        .map_err(|e| AppError::InternalError(format!("encode url: {e}")))?;
-    let method_json = serde_json::to_string(&method)
-        .map_err(|e| AppError::InternalError(format!("encode method: {e}")))?;
-    Ok(format!(
-        r#"
-        const cb = arguments[arguments.length - 1];
-        const opts = {{ method: {method_json}, headers: {headers_json}, credentials: 'include' }};
-        const body = {body_json};
-        if (body !== '' && {method_json} !== 'GET') opts.body = body;
-        fetch({url_json}, opts)
-          .then(async (r) => {{
-            const text = await r.text();
-            const hdrs = {{}};
-            r.headers.forEach((v, k) => {{ hdrs[k] = v; }});
-            cb({{ status: r.status, headers: hdrs, body: text }});
-          }})
-          .catch((e) => cb({{ status: 0, headers: {{}}, body: String(e) }}));
-        "#
-    ))
+fn domain_of(url: &str) -> Result<String, AppError> {
+    let parsed =
+        url::Url::parse(url).map_err(|e| AppError::BadRequest(format!("invalid url: {e}")))?;
+    Ok(parsed.host_str().unwrap_or("").to_string())
+}
+
+fn referer_header(req: &FetchRequest) -> Option<String> {
+    req.headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("referer"))
+        .map(|(_, v)| v.clone())
 }

--- a/px-camoufox/src/infrastructure/camoufox_pool.rs
+++ b/px-camoufox/src/infrastructure/camoufox_pool.rs
@@ -11,9 +11,12 @@ use tokio::process::Command;
 use tokio::sync::Semaphore;
 use tokio::time::sleep;
 
+use crate::infrastructure::session_pool::SessionPool;
+
 pub struct CamoufoxPool {
     pub(crate) config: CamoufoxConfig,
     pub(crate) permits: Arc<Semaphore>,
+    pub(crate) sessions: Arc<SessionPool>,
 }
 
 impl CamoufoxPool {
@@ -22,7 +25,12 @@ impl CamoufoxPool {
             .validate()
             .map_err(|e| AppError::InternalError(format!("camoufox config: {e}")))?;
         let permits = Arc::new(Semaphore::new(config.max_concurrent));
-        Ok(Self { config, permits })
+        let sessions = Arc::new(SessionPool::new(config.clone(), Duration::from_secs(300)));
+        Ok(Self {
+            config,
+            permits,
+            sessions,
+        })
     }
 
     /// Spawn geckodriver + Camoufox, hand the resulting webdriver

--- a/px-camoufox/src/infrastructure/fetch_script.rs
+++ b/px-camoufox/src/infrastructure/fetch_script.rs
@@ -1,0 +1,33 @@
+//! JS fragment that runs an in-page `fetch` inside Camoufox and posts
+//! the response back to fantoccini via `execute_async`'s callback.
+
+use px_errors::AppError;
+use px_pipeline::FetchRequest;
+
+pub(crate) fn build(req: &FetchRequest) -> Result<String, AppError> {
+    let method = req.method().to_string();
+    let headers_json = serde_json::to_string(&req.headers)
+        .map_err(|e| AppError::InternalError(format!("encode headers: {e}")))?;
+    let body_json = serde_json::to_string(req.body.as_deref().unwrap_or(""))
+        .map_err(|e| AppError::InternalError(format!("encode body: {e}")))?;
+    let url_json = serde_json::to_string(&req.url)
+        .map_err(|e| AppError::InternalError(format!("encode url: {e}")))?;
+    let method_json = serde_json::to_string(&method)
+        .map_err(|e| AppError::InternalError(format!("encode method: {e}")))?;
+    Ok(format!(
+        r#"
+        const cb = arguments[arguments.length - 1];
+        const opts = {{ method: {method_json}, headers: {headers_json}, credentials: 'include' }};
+        const body = {body_json};
+        if (body !== '' && {method_json} !== 'GET') opts.body = body;
+        fetch({url_json}, opts)
+          .then(async (r) => {{
+            const text = await r.text();
+            const hdrs = {{}};
+            r.headers.forEach((v, k) => {{ hdrs[k] = v; }});
+            cb({{ status: r.status, headers: hdrs, body: text }});
+          }})
+          .catch((e) => cb({{ status: 0, headers: {{}}, body: String(e) }}));
+        "#
+    ))
+}

--- a/px-camoufox/src/infrastructure/fetch_strategies.rs
+++ b/px-camoufox/src/infrastructure/fetch_strategies.rs
@@ -1,0 +1,106 @@
+//! The two execution strategies for `/v1/fetch` against a persistent
+//! Camoufox session.
+//!
+//! * `navigate_and_read` (used for GET): drives the webdriver to the
+//!   target URL so the browser handles Cloudflare's interactive
+//!   challenge, then reads the response body via
+//!   `document.body.innerText`. Status is sniffed from the body shape
+//!   because webdriver doesn't surface response codes.
+//! * `in_page_fetch` (used for POST/PUT/etc.): runs an in-page
+//!   `fetch()` since webdriver navigation can't carry a request body.
+//!   Any CF interactive challenge surfaced here arrives as HTML and
+//!   is reported back as a 403.
+
+use crate::infrastructure::fetch_script;
+use px_errors::AppError;
+use px_pipeline::FetchRequest;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::time::sleep;
+
+pub(crate) type FetchTriple = (u16, HashMap<String, String>, String);
+
+pub(crate) async fn navigate_and_read(
+    client: &fantoccini::Client,
+    req: &FetchRequest,
+    navigate_timeout: Duration,
+) -> Result<FetchTriple, AppError> {
+    navigate_with_wait(
+        client,
+        &req.url,
+        navigate_timeout,
+        Duration::from_millis(3_500),
+    )
+    .await?;
+    let body_val = client
+        .execute("return document.body.innerText;", vec![])
+        .await
+        .map_err(|e| AppError::InternalError(format!("read body: {e}")))?;
+    let body = body_val.as_str().unwrap_or("").to_string();
+    let trimmed = body.trim_start();
+    let status = if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        200
+    } else if looks_like_challenge(&body) {
+        403
+    } else {
+        500
+    };
+    Ok((status, HashMap::new(), body))
+}
+
+pub(crate) async fn in_page_fetch(
+    client: &fantoccini::Client,
+    req: &FetchRequest,
+    request_timeout: Duration,
+) -> Result<FetchTriple, AppError> {
+    let script = fetch_script::build(req)?;
+    let exec = client.execute_async(&script, vec![]);
+    let raw = match tokio::time::timeout(request_timeout, exec).await {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => return Err(AppError::InternalError(format!("fetch eval: {e}"))),
+        Err(_) => return Err(AppError::InternalError("fetch timeout".into())),
+    };
+    let status = raw
+        .get("status")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| AppError::InternalError("fetch result missing status".into()))?
+        as u16;
+    let body = raw
+        .get("body")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let headers: HashMap<String, String> = raw
+        .get("headers")
+        .and_then(Value::as_object)
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok((status, headers, body))
+}
+
+fn looks_like_challenge(body: &str) -> bool {
+    body.contains("__cf_chl")
+        || body.contains("Just a moment")
+        || body.contains("\"appId\":\"PXeT15wiaE\"")
+        || body.contains("tráfico inusual")
+        || body.contains("trafico inusual")
+}
+
+pub(crate) async fn navigate_with_wait(
+    client: &fantoccini::Client,
+    url: &str,
+    navigate_timeout: Duration,
+    settle: Duration,
+) -> Result<(), AppError> {
+    let nav = client.goto(url);
+    if tokio::time::timeout(navigate_timeout, nav).await.is_err() {
+        return Err(AppError::InternalError(format!("navigate timeout: {url}")));
+    }
+    sleep(settle).await;
+    Ok(())
+}

--- a/px-camoufox/src/infrastructure/mod.rs
+++ b/px-camoufox/src/infrastructure/mod.rs
@@ -1,3 +1,7 @@
 pub mod camoufox_fetcher;
 pub mod camoufox_pool;
 pub mod caps;
+pub mod fetch_script;
+pub mod fetch_strategies;
+pub mod session;
+pub mod session_pool;

--- a/px-camoufox/src/infrastructure/session.rs
+++ b/px-camoufox/src/infrastructure/session.rs
@@ -1,0 +1,76 @@
+//! Long-lived Camoufox session that survives across multiple
+//! `/v1/fetch` calls. Spawning geckodriver + Camoufox costs ~13s on
+//! each fresh harvest, and rapid repeats trip PerimeterX's
+//! "tráfico inusual" rate limit — so the fetcher reuses one warm
+//! browser per allowed domain.
+
+use crate::domain::config::CamoufoxConfig;
+use crate::infrastructure::caps::{build_capabilities, pick_free_port, wait_for_geckodriver};
+use fantoccini::ClientBuilder;
+use px_errors::AppError;
+use std::time::{Duration, Instant};
+use tokio::process::Command;
+use tokio::sync::Mutex;
+
+/// A live Camoufox/geckodriver pair plus the webdriver client.
+/// Concurrent callers serialize on `inner` so a single browser only
+/// handles one fetch at a time (sharing it across threads would
+/// race on URL navigation).
+pub(crate) struct PersistentSession {
+    pub(crate) created_at: Instant,
+    pub(crate) inner: Mutex<Inner>,
+}
+
+pub(crate) struct Inner {
+    pub(crate) client: fantoccini::Client,
+    /// Held only for its `kill_on_drop(true)` semantics. Never read.
+    #[allow(dead_code)]
+    pub(crate) child: tokio::process::Child,
+    pub(crate) last_used: Instant,
+    pub(crate) fetch_count: u64,
+    /// `true` after the first homepage navigation has happened, so
+    /// subsequent fetches skip the warm-up step.
+    pub(crate) warmed: bool,
+}
+
+impl PersistentSession {
+    pub(crate) async fn spawn(config: &CamoufoxConfig, domain: &str) -> Result<Self, AppError> {
+        let port = pick_free_port().await?;
+        let child = Command::new(&config.geckodriver_bin)
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--binary")
+            .arg(&config.camoufox_bin)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| AppError::InternalError(format!("spawn geckodriver: {e}")))?;
+        wait_for_geckodriver(port, Duration::from_secs(15)).await?;
+        let caps = build_capabilities(config, None);
+        let endpoint = format!("http://127.0.0.1:{port}");
+        let client = ClientBuilder::native()
+            .capabilities(caps)
+            .connect(&endpoint)
+            .await
+            .map_err(|e| AppError::InternalError(format!("webdriver connect: {e}")))?;
+        tracing::info!(domain = %domain, port, "persistent Camoufox session spawned");
+        Ok(Self {
+            created_at: Instant::now(),
+            inner: Mutex::new(Inner {
+                client,
+                child,
+                last_used: Instant::now(),
+                fetch_count: 0,
+                warmed: false,
+            }),
+        })
+    }
+
+    /// Best-effort age check. Doesn't peek inside the lock — callers
+    /// outside the mutex use this only to short-circuit when the
+    /// session is obviously stale.
+    pub(crate) fn is_aged_out(&self, ttl: Duration) -> bool {
+        self.created_at.elapsed() > ttl
+    }
+}

--- a/px-camoufox/src/infrastructure/session_pool.rs
+++ b/px-camoufox/src/infrastructure/session_pool.rs
@@ -1,0 +1,67 @@
+//! Registry of `PersistentSession`s, keyed by target domain.
+//!
+//! Lazy spawn on first request; entries are recycled once they exceed
+//! the configured TTL. The pool does not bound concurrent acquires —
+//! one session per domain is the throttle, since callers serialize on
+//! that session's mutex.
+
+use crate::domain::config::CamoufoxConfig;
+use crate::infrastructure::session::PersistentSession;
+use px_errors::AppError;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+pub(crate) struct SessionPool {
+    config: CamoufoxConfig,
+    sessions: Mutex<HashMap<String, Arc<PersistentSession>>>,
+    ttl: Duration,
+}
+
+impl SessionPool {
+    pub(crate) fn new(config: CamoufoxConfig, ttl: Duration) -> Self {
+        Self {
+            config,
+            sessions: Mutex::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    /// Returns the warm session for `domain`, spawning a new one (and
+    /// evicting any aged-out predecessor) when needed. Spawning a fresh
+    /// browser holds the registry lock only briefly: the actual
+    /// geckodriver launch happens with the registry unlocked so other
+    /// domains can be acquired in parallel.
+    pub(crate) async fn acquire(&self, domain: &str) -> Result<Arc<PersistentSession>, AppError> {
+        {
+            let mut guard = self.sessions.lock().await;
+            if let Some(existing) = guard.get(domain)
+                && !existing.is_aged_out(self.ttl)
+            {
+                return Ok(Arc::clone(existing));
+            }
+            if guard.contains_key(domain) {
+                tracing::info!(%domain, "recycling aged-out Camoufox session");
+                guard.remove(domain);
+            }
+        }
+        let fresh = Arc::new(PersistentSession::spawn(&self.config, domain).await?);
+        let mut guard = self.sessions.lock().await;
+        // Double-check: another task may have raced and inserted a fresh
+        // entry while we were spawning. Prefer the existing one to avoid
+        // leaking the just-spawned browser.
+        if let Some(existing) = guard.get(domain)
+            && !existing.is_aged_out(self.ttl)
+        {
+            return Ok(Arc::clone(existing));
+        }
+        guard.insert(domain.into(), Arc::clone(&fresh));
+        Ok(fresh)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn len(&self) -> usize {
+        self.sessions.lock().await.len()
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the spawn-per-fetch model with a per-domain warm Camoufox session that survives across `/v1/fetch` calls.

Three concrete wins, in order of importance:

1. **PerimeterX rate-limit avoidance.** With spawn-per-fetch, after roughly the 5th `/v1/fetch` against the same target the upstream starts serving `"tráfico inusual"` HTML and every subsequent fetch is a 403. Reusing one coherent browser session per domain keeps PX from flagging the IP as automation.
2. **Cold-start cost paid once.** Geckodriver + Camoufox launch is ~13s on a warm machine. With the pool, that cost is amortized across every fetch to the same host instead of charged per call.
3. **`cf_clearance` reuse.** Cloudflare's managed challenge runs once during the first navigation; the cookie lives in the browser jar for the rest of the session, so subsequent fetches don't re-execute the challenge.

## Architecture

```
infrastructure/
├── camoufox_pool.rs        // unchanged Harvester impl; now also owns Arc<SessionPool>
├── camoufox_fetcher.rs     // Fetcher impl — acquire session, warm, dispatch GET/POST
├── session.rs              // PersistentSession { fantoccini::Client + Child + Mutex<Inner> }
├── session_pool.rs         // HashMap<domain, Arc<PersistentSession>>, 5-min TTL, race-safe spawn
├── fetch_strategies.rs     // navigate_and_read (GET) + in_page_fetch (POST)
├── fetch_script.rs         // the in-page fetch() JS builder
└── caps.rs                 // unchanged shared geckodriver helpers
```

GET requests run through `navigate_and_read` — webdriver navigates the browser to the target URL so any Cloudflare interactive challenge gets solved natively, then reads response via `document.body.innerText`. POSTs fall back to `in_page_fetch` because webdriver navigation can't carry a body.

## Operational notes
- Session TTL is hardcoded at 5 minutes; lifecycle/eviction policy is an ADR-level follow-up if this needs to be configurable.
- Concurrent fetches against the same domain serialize on the session's mutex. Intentional — one warm browser can't handle parallel navigations safely.
- No background reaper; aged-out sessions are recycled lazily on the next `acquire()` call for that domain.
- Process exit cleans up via `kill_on_drop(true)` on each `tokio::process::Child` held by the session — `SessionPool`'s HashMap drops, which drops the sessions, which drops the children, which sends SIGKILL.
- Harvest path (`/v1/solve`) is unchanged; only `/v1/fetch` uses the pool.

## Live validation deferred
The implementation has been smoke-tested on the local box, but the test IP is currently sitting under a pedidosya PerimeterX rate-limit ("tráfico inusual" body) from the many ad-hoc `/v1/solve` calls made while debugging upstream JA3 / cookie-replay issues earlier. The rate limit is not specific to this change — it also blocks the merged v1.4.0 binary. Re-running this once the rate limit lifts (or from a fresh IP) is the verification path before shipping in a release.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` against the lefthook rule set (`-D warnings -D unwrap_used -D expect_used -D panic -D dbg_macro -D todo -D unimplemented`)
- [x] `cargo test --workspace --lib` — all existing tests pass; no new tests for the pool because spawning Camoufox in CI is out of scope here
- [x] Lefthook pre-commit + pre-push hooks pass locally (fmt, clippy, loc≤200, forbidden-patterns)
- [x] Each new file under the 200-LOC axum-best-practice rule (camoufox_fetcher.rs trimmed to 112, fetch_strategies.rs 106)
- [ ] Live: re-run pedidosya canary after PX rate-limit clears

## Follow-ups
- ADR for session lifetime configuration knobs (TTL, max_fetches_per_session, max_total_sessions).
- Background reaper task so aged-out browsers don't sit until the next acquire.
- Chromium-pool Fetcher impl for PX-only (non-CF) targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)