### PR TITLE
perf(camoufox): tune fetcher for 30+ req/min target

### DIFF
--- a/px-camoufox/src/infrastructure/camoufox_fetcher.rs
+++ b/px-camoufox/src/infrastructure/camoufox_fetcher.rs
@@ -48,25 +48,32 @@ async fn run_through_session(
             &inner.client,
             &origin,
             navigate_timeout,
-            Duration::from_millis(4_000),
+            Duration::from_millis(2_500),
         )
         .await
         {
             tracing::warn!(error = %e, "session warmup failed; downstream will likely 403");
         } else {
             inner.warmed = true;
+            inner.last_visited = Some(origin);
         }
     }
+    // Navigate to the referer only when it actually differs from where
+    // the webdriver is currently parked. Saves a full 1-2s nav per
+    // fetch when consecutive callers share the same SPA page.
     if let Some(referer) = referer_header(&req)
         && !referer.is_empty()
-    {
-        let _ = navigate_with_wait(
+        && inner.last_visited.as_deref() != Some(referer.as_str())
+        && navigate_with_wait(
             &inner.client,
             &referer,
             navigate_timeout,
-            Duration::from_millis(2_000),
+            Duration::from_millis(1_000),
         )
-        .await;
+        .await
+        .is_ok()
+    {
+        inner.last_visited = Some(referer);
     }
 
     let outcome = if req.method().eq_ignore_ascii_case("GET") {
@@ -74,6 +81,9 @@ async fn run_through_session(
     } else {
         in_page_fetch(&inner.client, &req, request_timeout).await
     };
+    if req.method().eq_ignore_ascii_case("GET") {
+        inner.last_visited = Some(req.url.clone());
+    }
     inner.last_used = Instant::now();
     inner.fetch_count = inner.fetch_count.saturating_add(1);
     drop(inner);

--- a/px-camoufox/src/infrastructure/camoufox_pool.rs
+++ b/px-camoufox/src/infrastructure/camoufox_pool.rs
@@ -25,7 +25,15 @@ impl CamoufoxPool {
             .validate()
             .map_err(|e| AppError::InternalError(format!("camoufox config: {e}")))?;
         let permits = Arc::new(Semaphore::new(config.max_concurrent));
-        let sessions = Arc::new(SessionPool::new(config.clone(), Duration::from_secs(300)));
+        let max_per_domain = std::env::var("PX_FETCH_MAX_PER_DOMAIN")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(2);
+        let sessions = Arc::new(SessionPool::new(
+            config.clone(),
+            Duration::from_secs(300),
+            max_per_domain,
+        ));
         Ok(Self {
             config,
             permits,

--- a/px-camoufox/src/infrastructure/fetch_strategies.rs
+++ b/px-camoufox/src/infrastructure/fetch_strategies.rs
@@ -26,11 +26,14 @@ pub(crate) async fn navigate_and_read(
     req: &FetchRequest,
     navigate_timeout: Duration,
 ) -> Result<FetchTriple, AppError> {
+    // Warm session has CF clearance already; the new navigation only
+    // needs DOM to settle before we read body text. 1s is enough for
+    // the niles JSON endpoint to render `document.body.innerText`.
     navigate_with_wait(
         client,
         &req.url,
         navigate_timeout,
-        Duration::from_millis(3_500),
+        Duration::from_millis(1_000),
     )
     .await?;
     let body_val = client

--- a/px-camoufox/src/infrastructure/session.rs
+++ b/px-camoufox/src/infrastructure/session.rs
@@ -31,6 +31,10 @@ pub(crate) struct Inner {
     /// `true` after the first homepage navigation has happened, so
     /// subsequent fetches skip the warm-up step.
     pub(crate) warmed: bool,
+    /// The URL the webdriver is currently parked on. Used to skip a
+    /// redundant referer navigation when the new request would land
+    /// on the same page anyway.
+    pub(crate) last_visited: Option<String>,
 }
 
 impl PersistentSession {
@@ -63,6 +67,7 @@ impl PersistentSession {
                 last_used: Instant::now(),
                 fetch_count: 0,
                 warmed: false,
+                last_visited: None,
             }),
         })
     }

--- a/px-camoufox/src/infrastructure/session_pool.rs
+++ b/px-camoufox/src/infrastructure/session_pool.rs
@@ -1,67 +1,89 @@
 //! Registry of `PersistentSession`s, keyed by target domain.
 //!
-//! Lazy spawn on first request; entries are recycled once they exceed
-//! the configured TTL. The pool does not bound concurrent acquires —
-//! one session per domain is the throttle, since callers serialize on
-//! that session's mutex.
+//! For each domain we hold up to `max_per_domain` warm browsers, picked
+//! round-robin per acquire. That lets `/v1/fetch` parallelize against
+//! the same target while each session still holds the upstream's
+//! coherent cookie jar.
 
 use crate::domain::config::CamoufoxConfig;
 use crate::infrastructure::session::PersistentSession;
 use px_errors::AppError;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::sync::Mutex;
 
+#[derive(Default)]
+struct DomainSlot {
+    sessions: Vec<Arc<PersistentSession>>,
+    /// Round-robin cursor for `pick`.
+    cursor: AtomicUsize,
+}
+
 pub(crate) struct SessionPool {
     config: CamoufoxConfig,
-    sessions: Mutex<HashMap<String, Arc<PersistentSession>>>,
+    domains: Mutex<HashMap<String, DomainSlot>>,
     ttl: Duration,
+    max_per_domain: usize,
 }
 
 impl SessionPool {
-    pub(crate) fn new(config: CamoufoxConfig, ttl: Duration) -> Self {
+    pub(crate) fn new(config: CamoufoxConfig, ttl: Duration, max_per_domain: usize) -> Self {
         Self {
             config,
-            sessions: Mutex::new(HashMap::new()),
+            domains: Mutex::new(HashMap::new()),
             ttl,
+            max_per_domain: max_per_domain.max(1),
         }
     }
 
-    /// Returns the warm session for `domain`, spawning a new one (and
-    /// evicting any aged-out predecessor) when needed. Spawning a fresh
-    /// browser holds the registry lock only briefly: the actual
-    /// geckodriver launch happens with the registry unlocked so other
-    /// domains can be acquired in parallel.
+    /// Acquire a session for `domain`. If the slot has room, lazily
+    /// spawns a new browser; otherwise rotates round-robin across the
+    /// existing sessions. Aged-out sessions are dropped on the way.
     pub(crate) async fn acquire(&self, domain: &str) -> Result<Arc<PersistentSession>, AppError> {
         {
-            let mut guard = self.sessions.lock().await;
-            if let Some(existing) = guard.get(domain)
-                && !existing.is_aged_out(self.ttl)
-            {
-                return Ok(Arc::clone(existing));
+            let mut guard = self.domains.lock().await;
+            let slot = guard
+                .entry(domain.to_string())
+                .or_insert_with(DomainSlot::default);
+            let before = slot.sessions.len();
+            slot.sessions.retain(|s| !s.is_aged_out(self.ttl));
+            if slot.sessions.len() < before {
+                tracing::info!(
+                    %domain,
+                    evicted = before - slot.sessions.len(),
+                    "evicted aged-out Camoufox sessions"
+                );
             }
-            if guard.contains_key(domain) {
-                tracing::info!(%domain, "recycling aged-out Camoufox session");
-                guard.remove(domain);
+            if slot.sessions.len() >= self.max_per_domain {
+                let idx = slot.cursor.fetch_add(1, Ordering::Relaxed) % slot.sessions.len();
+                return Ok(Arc::clone(&slot.sessions[idx]));
             }
         }
         let fresh = Arc::new(PersistentSession::spawn(&self.config, domain).await?);
-        let mut guard = self.sessions.lock().await;
-        // Double-check: another task may have raced and inserted a fresh
-        // entry while we were spawning. Prefer the existing one to avoid
-        // leaking the just-spawned browser.
-        if let Some(existing) = guard.get(domain)
-            && !existing.is_aged_out(self.ttl)
-        {
-            return Ok(Arc::clone(existing));
+        let mut guard = self.domains.lock().await;
+        let slot = guard
+            .entry(domain.to_string())
+            .or_insert_with(DomainSlot::default);
+        if slot.sessions.len() < self.max_per_domain {
+            slot.sessions.push(Arc::clone(&fresh));
+            return Ok(fresh);
         }
-        guard.insert(domain.into(), Arc::clone(&fresh));
-        Ok(fresh)
+        // Race: somebody else filled the slot while we spawned. Pick
+        // one of the existing sessions; the just-spawned browser drops
+        // here (kill_on_drop fires when `fresh`'s Arc count hits 0).
+        let idx = slot.cursor.fetch_add(1, Ordering::Relaxed) % slot.sessions.len();
+        Ok(Arc::clone(&slot.sessions[idx]))
     }
 
     #[allow(dead_code)]
-    pub(crate) async fn len(&self) -> usize {
-        self.sessions.lock().await.len()
+    pub(crate) async fn total_sessions(&self) -> usize {
+        self.domains
+            .lock()
+            .await
+            .values()
+            .map(|slot| slot.sessions.len())
+            .sum()
     }
 }


### PR DESCRIPTION
## Summary
Three changes that move `/v1/fetch` from ~6 req/min toward the ≥30 req/min the downstream pedidosya scraper needs.

### 1. Trim per-fetch settles
| Stage | Before | After |
|---|---|---|
| Homepage warm-up (one-time per session) | 4000 ms | 2500 ms |
| Referer navigation | 2000 ms | 1000 ms |
| GET target navigation in `navigate_and_read` | 3500 ms | 1000 ms |

`cf_clearance` lands in well under 2.5s in practice; the previous 4s was pure paranoia padding. The niles JSON endpoint surfaces in `document.body.innerText` well under a second after navigating from a warm session.

### 2. Skip the referer navigation when redundant
New `Inner.last_visited: Option<String>` tracks the most recent navigation; the fetcher consults it before issuing what would otherwise be a no-op `goto`. Saves ~2s per fetch when consecutive callers share the same SPA page (the common case for `/v4/shoplist/vendors` POSTs).

### 3. Multi-session per domain
`SessionPool` now holds up to `PX_FETCH_MAX_PER_DOMAIN` (env, default `2`) warm browsers per domain and round-robins across them. Two parallel sessions double the per-domain throughput ceiling so concurrent `/v1/fetch` callers don't serialize on a single mutex.

Each session still serializes its own callers (one browser = one fetch at a time), and `kill_on_drop(true)` on each child means a race in `acquire` that spawns an over-quota browser drops it immediately when the `Arc` goes out of scope.

## Back-of-envelope math on a warm session
- Same-page consecutive fetches: ~1.5s each (target nav only).
- Cross-page fetches: ~3s each (referer + target nav).
- With `max_per_domain=2`, parallel callers ≈ 2× throughput ceiling.

So 30 req/min single-thread is feasible for same-page batches; the 2-session default keeps headroom for mixed workloads.

## Why
The downstream pedidosya scraper has a stated throughput target of **≥30 fetch requests per minute** (~1408 vendors per area / under an hour). Without this tuning the previous PR (#7) lands at ~6 req/min sustained, turning each area scrape into a multi-hour job.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` against the lefthook rule set (`-D warnings -D unwrap_used -D expect_used -D panic -D dbg_macro -D todo -D unimplemented`)
- [x] `cargo test --workspace --lib` — all pre-existing tests pass; no new tests for the pool since spawning real Camoufox in CI is out of scope (manual smoke is the validation path)
- [x] Lefthook pre-commit + pre-push hooks pass locally
- [x] Each file under the 200-LOC axum-best-practice rule (session_pool.rs grew from 67 to 89)
- [ ] Live validation against pedidosya: still gated on the test IP's PX rate-limit clearing. The tuning is structurally correct; reproducing 30 req/min requires either a cooled-off IP or proxy rotation (separate ADR-level follow-up).

## What's not in this PR
- Background reaper for aged-out sessions (still lazy on next acquire).
- Per-domain max-sessions config (uses one global `PX_FETCH_MAX_PER_DOMAIN`).
- Chromium-pool Fetcher impl for PX-only targets — only the Camoufox path benefits today.
- Proxy rotation — the real WAF defense for sustained scraping. Tracked as a separate thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)