### PR TITLE
feat(camoufox): rotate egress proxies across /v1/fetch sessions

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,6 +127,19 @@ The optional `handler:` field (added in v1.1.x per [ADR-0023](adr/0023-allowlist
 
 Currently the server reads `PX_BIND`, `PX_KEYS`, `PX_ALLOWLIST` env vars. A YAML config file is reserved for future use.
 
+### Egress proxy rotation (optional)
+
+For sustained `/v1/fetch` traffic against rate-limiting WAFs (pedidosya's PerimeterX flags a single IP after ~30 fetches/min), set `PX_PROXIES` to a CSV list of proxy URLs. Each persistent Camoufox session for a CF-routed domain is assigned a proxy round-robin from the list:
+
+```bash
+PX_PROXIES="http://user:pass@proxy1.example:8080,socks5://user:pass@proxy2.example:1080" \
+./target/release/px-server
+```
+
+Empty / unset → direct connection (no rotation). Both `http://` and `socks5://` schemes are accepted by the underlying geckodriver capability. With `PX_FETCH_MAX_PER_DOMAIN=N` (default 2), the pool spawns up to N browsers per domain, each binding to the next proxy in the rotation; the operator's effective concurrency is `N × len(proxies)` parallel egress paths before round-robin reuse kicks in.
+
+Tor as a quick test: install `tor`, let it bind `socks5://127.0.0.1:9050`, set `PX_PROXIES="socks5://127.0.0.1:9050"`. Many sites block Tor exit IPs; treat it as a fingerprint smoke-test rather than a production proxy.
+
 ## Run
 
 ```bash

--- a/px-camoufox/src/infrastructure/camoufox_pool.rs
+++ b/px-camoufox/src/infrastructure/camoufox_pool.rs
@@ -11,6 +11,7 @@ use tokio::process::Command;
 use tokio::sync::Semaphore;
 use tokio::time::sleep;
 
+use crate::infrastructure::proxy_pool::ProxyPool;
 use crate::infrastructure::session_pool::SessionPool;
 
 pub struct CamoufoxPool {
@@ -29,10 +30,18 @@ impl CamoufoxPool {
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
             .unwrap_or(2);
+        let proxies = Arc::new(ProxyPool::from_env("PX_PROXIES"));
+        if !proxies.is_empty() {
+            tracing::info!(
+                count = proxies.len(),
+                "proxy rotation enabled for /v1/fetch sessions"
+            );
+        }
         let sessions = Arc::new(SessionPool::new(
             config.clone(),
             Duration::from_secs(300),
             max_per_domain,
+            proxies,
         ));
         Ok(Self {
             config,

--- a/px-camoufox/src/infrastructure/mod.rs
+++ b/px-camoufox/src/infrastructure/mod.rs
@@ -3,5 +3,6 @@ pub mod camoufox_pool;
 pub mod caps;
 pub mod fetch_script;
 pub mod fetch_strategies;
+pub mod proxy_pool;
 pub mod session;
 pub mod session_pool;

--- a/px-camoufox/src/infrastructure/proxy_pool.rs
+++ b/px-camoufox/src/infrastructure/proxy_pool.rs
@@ -1,0 +1,108 @@
+//! Egress-IP rotation for Camoufox sessions.
+//!
+//! Pedidosya's PerimeterX (and most aggressive WAFs) rate-limit by
+//! source IP. When the operator wants sustained scraping above what a
+//! single IP can sustain (~10-30 req/min before flagging), each
+//! `PersistentSession` should attach to a different egress proxy.
+//!
+//! Config is operator-side: a list of proxy URLs supplied via env or
+//! by the embedder. `ProxyPool::next` round-robins through the list;
+//! a `None` return signals "go direct" so the operator can opt out
+//! by not setting any proxies.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Default)]
+pub struct ProxyPool {
+    proxies: Vec<String>,
+    cursor: AtomicUsize,
+}
+
+impl ProxyPool {
+    pub fn new(proxies: Vec<String>) -> Self {
+        // Strip blank entries so a trailing comma in `PX_PROXIES`
+        // doesn't poison the rotation.
+        let proxies = proxies
+            .into_iter()
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect();
+        Self {
+            proxies,
+            cursor: AtomicUsize::new(0),
+        }
+    }
+
+    /// Parse `PX_PROXIES` CSV into a pool. Unset / empty → empty pool
+    /// (direct connection).
+    pub fn from_env(var: &str) -> Self {
+        let raw = std::env::var(var).unwrap_or_default();
+        let entries = raw.split(',').map(|s| s.to_string()).collect();
+        Self::new(entries)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.proxies.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.proxies.len()
+    }
+
+    /// Next proxy by round-robin order. `None` when the pool is empty —
+    /// the caller treats that as "no proxy, use the default route".
+    pub fn next(&self) -> Option<String> {
+        if self.proxies.is_empty() {
+            return None;
+        }
+        let idx = self.cursor.fetch_add(1, Ordering::Relaxed) % self.proxies.len();
+        Some(self.proxies[idx].clone())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_pool_returns_none() {
+        let pool = ProxyPool::new(vec![]);
+        assert!(pool.is_empty());
+        assert!(pool.next().is_none());
+    }
+
+    #[test]
+    fn round_robins_across_entries() {
+        let pool = ProxyPool::new(vec![
+            "http://a:1".into(),
+            "http://b:2".into(),
+            "http://c:3".into(),
+        ]);
+        let picks: Vec<String> = (0..6).filter_map(|_| pool.next()).collect();
+        assert_eq!(
+            picks,
+            vec![
+                "http://a:1",
+                "http://b:2",
+                "http://c:3",
+                "http://a:1",
+                "http://b:2",
+                "http://c:3",
+            ]
+        );
+    }
+
+    #[test]
+    fn trims_blank_and_whitespace_entries() {
+        let pool = ProxyPool::new(vec![
+            "  http://a:1 ".into(),
+            "".into(),
+            "   ".into(),
+            "http://b:2".into(),
+        ]);
+        assert_eq!(pool.len(), 2);
+        assert_eq!(pool.next().as_deref(), Some("http://a:1"));
+        assert_eq!(pool.next().as_deref(), Some("http://b:2"));
+    }
+}

--- a/px-camoufox/src/infrastructure/session.rs
+++ b/px-camoufox/src/infrastructure/session.rs
@@ -38,7 +38,11 @@ pub(crate) struct Inner {
 }
 
 impl PersistentSession {
-    pub(crate) async fn spawn(config: &CamoufoxConfig, domain: &str) -> Result<Self, AppError> {
+    pub(crate) async fn spawn(
+        config: &CamoufoxConfig,
+        domain: &str,
+        proxy: Option<&str>,
+    ) -> Result<Self, AppError> {
         let port = pick_free_port().await?;
         let child = Command::new(&config.geckodriver_bin)
             .arg("--port")
@@ -51,14 +55,19 @@ impl PersistentSession {
             .spawn()
             .map_err(|e| AppError::InternalError(format!("spawn geckodriver: {e}")))?;
         wait_for_geckodriver(port, Duration::from_secs(15)).await?;
-        let caps = build_capabilities(config, None);
+        let caps = build_capabilities(config, proxy);
         let endpoint = format!("http://127.0.0.1:{port}");
         let client = ClientBuilder::native()
             .capabilities(caps)
             .connect(&endpoint)
             .await
             .map_err(|e| AppError::InternalError(format!("webdriver connect: {e}")))?;
-        tracing::info!(domain = %domain, port, "persistent Camoufox session spawned");
+        tracing::info!(
+            domain = %domain,
+            port,
+            proxy = proxy.unwrap_or("direct"),
+            "persistent Camoufox session spawned"
+        );
         Ok(Self {
             created_at: Instant::now(),
             inner: Mutex::new(Inner {

--- a/px-camoufox/src/infrastructure/session_pool.rs
+++ b/px-camoufox/src/infrastructure/session_pool.rs
@@ -6,6 +6,7 @@
 //! coherent cookie jar.
 
 use crate::domain::config::CamoufoxConfig;
+use crate::infrastructure::proxy_pool::ProxyPool;
 use crate::infrastructure::session::PersistentSession;
 use px_errors::AppError;
 use std::collections::HashMap;
@@ -26,15 +27,22 @@ pub(crate) struct SessionPool {
     domains: Mutex<HashMap<String, DomainSlot>>,
     ttl: Duration,
     max_per_domain: usize,
+    proxies: Arc<ProxyPool>,
 }
 
 impl SessionPool {
-    pub(crate) fn new(config: CamoufoxConfig, ttl: Duration, max_per_domain: usize) -> Self {
+    pub(crate) fn new(
+        config: CamoufoxConfig,
+        ttl: Duration,
+        max_per_domain: usize,
+        proxies: Arc<ProxyPool>,
+    ) -> Self {
         Self {
             config,
             domains: Mutex::new(HashMap::new()),
             ttl,
             max_per_domain: max_per_domain.max(1),
+            proxies,
         }
     }
 
@@ -61,7 +69,9 @@ impl SessionPool {
                 return Ok(Arc::clone(&slot.sessions[idx]));
             }
         }
-        let fresh = Arc::new(PersistentSession::spawn(&self.config, domain).await?);
+        let proxy = self.proxies.next();
+        let fresh =
+            Arc::new(PersistentSession::spawn(&self.config, domain, proxy.as_deref()).await?);
         let mut guard = self.domains.lock().await;
         let slot = guard
             .entry(domain.to_string())


### PR DESCRIPTION
## Summary
Adds operator-side proxy rotation for the persistent Camoufox session pool. With `PX_PROXIES` set, each newly-spawned session binds to the next proxy in round-robin order. Empty/unset → direct connection (no behavioural change).

This is the structural answer to "sustained scraping above what a single IP can carry": pedidosya's PerimeterX rate-limits the egress at roughly 10-30 req/min before serving block pages, so the only way to feed a downstream like the pedidosya scraper its required ≥40 req/min is to fan out across multiple egress IPs.

## What's in
- **`infrastructure/proxy_pool.rs`** — `ProxyPool::from_env("PX_PROXIES")` parses a CSV (whitespace-trimmed, blanks dropped); `.next()` returns `Option<String>` round-robin via an `AtomicUsize` cursor. `None` = "no proxy, go direct". 3 unit tests cover empty pool / rotation order / trimming.
- **`PersistentSession::spawn`** now accepts `proxy: Option<&str>` and threads it into `build_capabilities`, which translates to the standard webdriver `proxy` capability (handled by geckodriver as Firefox network prefs).
- **`SessionPool`** takes `Arc<ProxyPool>` in its constructor; the lazy-spawn branch of `acquire` pulls `proxies.next()` before constructing the session. Sessions stick to their proxy for their entire 5-min TTL so cookies + JA3 + egress stay coherent.
- **`CamoufoxPool::new`** reads `PX_PROXIES` at startup and logs the rotation size, so the operator can confirm direct vs proxied mode from a single startup line.

## What's not in (intentional)
- **Per-proxy health tracking.** A dead proxy in the rotation surfaces as the matching session's first fetch failing; the session ages out via the TTL. A follow-up can add success/fail counters and skip-broken-proxy logic — that's an ADR-level conversation about the error model and eviction policy.
- **Solve-path rotation.** `/v1/solve` still consumes the caller-supplied `HarvestRequest.proxy`. Solves are infrequent, operator-driven, and already have a hook; auto-rotation there is its own decision.
- **No per-session sticky-proxy retry.** Combined with PR #8's backoff retry, a session that's blocked won't be re-acquired with a different proxy until it ages out. A targeted retry-with-new-proxy is a follow-up.

## Why
Live testing against pedidosya in the previous session triggered the WAF's IP-level rate limit ("tráfico inusual" Spanish block page) after about 50 ad-hoc calls. No code change to the session pool, fetcher, or scraper helps a flagged IP; the only real defenses are (a) wait, (b) rotate IPs. This PR is (b).

## Deployment

```bash
PX_PROXIES="http://user:pass@proxy1.example:8080,socks5://user:pass@proxy2.example:1080" \
PX_FETCH_MAX_PER_DOMAIN=2 \
./target/release/px-server
```

With `PX_FETCH_MAX_PER_DOMAIN=N` and `len(proxies)=M`, the pool spawns up to `N` browsers per domain, each on the next proxy in the rotation. Effective concurrent egress paths = `N × min(M, N)` before round-robin reuse begins.

[Tor smoke-test recipe in deployment.md.]

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` against the lefthook rule set
- [x] `cargo test -p pxsolver-camoufox --lib` — 5 tests passing (2 pre-existing config tests + 3 new `proxy_pool::tests`)
- [x] Lefthook pre-commit hooks pass locally (fmt, clippy, loc≤200, forbidden-patterns)
- [x] Each file under the 200-LOC axum-best-practice rule (`session_pool.rs` 99, `proxy_pool.rs` 108)
- [ ] Live: end-to-end smoke against pedidosya with at least 2 proxies — operator-side, the test box currently has none and the home IP is still PX-rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)