### PR TITLE
feat(camoufox): synthetic-user pool + humanize + SOCKS5 auth-relay caps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ config/server.yaml
 !px-research/sensor-maps/**/*.json
 !px-research/fingerprints/**/*.json
 !px-research/deobf/**/*.js
+graphify-out/

--- a/px-camoufox/src/domain/config.rs
+++ b/px-camoufox/src/domain/config.rs
@@ -49,13 +49,14 @@ impl CamoufoxConfig {
         let geckodriver_bin = std::env::var_os("PX_GECKODRIVER_BIN")
             .map(PathBuf::from)
             .unwrap_or_else(|| home.join(".local/bin/geckodriver"));
+        let locale = std::env::var("PX_CAMOUFOX_LOCALE").unwrap_or_else(|_| "en-US".into());
         Self {
             camoufox_bin,
             geckodriver_bin,
             headless: true,
             max_concurrent: 2,
             navigate_timeout: Duration::from_secs(45),
-            locale: "en-US".into(),
+            locale,
             timezone: None,
         }
     }

--- a/px-camoufox/src/infrastructure/camoufox_fetcher.rs
+++ b/px-camoufox/src/infrastructure/camoufox_fetcher.rs
@@ -10,9 +10,7 @@
 //! See `fetch_strategies` for both.
 
 use crate::infrastructure::camoufox_pool::CamoufoxPool;
-use crate::infrastructure::fetch_strategies::{
-    in_page_fetch, navigate_and_read, navigate_with_wait,
-};
+use crate::infrastructure::fetch_strategies::{humanize_for, in_page_fetch, navigate_with_wait};
 use crate::infrastructure::session::PersistentSession;
 use async_trait::async_trait;
 use px_errors::AppError;
@@ -40,13 +38,18 @@ async fn run_through_session(
     let started = Instant::now();
     let mut inner = session.inner.lock().await;
 
-    // Warm the browser once per session: load the origin so Cloudflare's
-    // managed challenge JS runs and `cf_clearance` lands in the jar.
-    if !inner.warmed {
-        let origin = origin_of(&req.url)?;
+    // Always land on the bare origin. Many SPA pages (vendor menu
+    // pages, listings) are PX-captcha-gated for direct webdriver
+    // navigation even on clean residential IPs; the homepage is the
+    // single "soft" entry that consistently passes. The caller's
+    // referer header is still sent on the in-page `fetch` so the
+    // upstream sees a plausible navigation chain — we just don't
+    // actually navigate the browser to that URL.
+    let landing = origin_of(&req.url).unwrap_or_else(|_| req.url.clone());
+    if !inner.warmed || inner.last_visited.as_deref() != Some(landing.as_str()) {
         if let Err(e) = navigate_with_wait(
             &inner.client,
-            &origin,
+            &landing,
             navigate_timeout,
             Duration::from_millis(2_500),
         )
@@ -55,35 +58,16 @@ async fn run_through_session(
             tracing::warn!(error = %e, "session warmup failed; downstream will likely 403");
         } else {
             inner.warmed = true;
-            inner.last_visited = Some(origin);
+            inner.last_visited = Some(landing);
         }
     }
-    // Navigate to the referer only when it actually differs from where
-    // the webdriver is currently parked. Saves a full 1-2s nav per
-    // fetch when consecutive callers share the same SPA page.
-    if let Some(referer) = referer_header(&req)
-        && !referer.is_empty()
-        && inner.last_visited.as_deref() != Some(referer.as_str())
-        && navigate_with_wait(
-            &inner.client,
-            &referer,
-            navigate_timeout,
-            Duration::from_millis(1_000),
-        )
-        .await
-        .is_ok()
-    {
-        inner.last_visited = Some(referer);
-    }
+    // Synthetic human noise + per-session synthetic identity. The user
+    // (GA / FB / first-visit timestamps) is bound for the session
+    // lifetime so PerimeterX sees a coherent returning visitor across
+    // every fetch in the same Camoufox process.
+    let _ = humanize_for(&inner.client, Some(&session.user)).await;
 
-    let outcome = if req.method().eq_ignore_ascii_case("GET") {
-        navigate_and_read(&inner.client, &req, navigate_timeout).await
-    } else {
-        in_page_fetch(&inner.client, &req, request_timeout).await
-    };
-    if req.method().eq_ignore_ascii_case("GET") {
-        inner.last_visited = Some(req.url.clone());
-    }
+    let outcome = in_page_fetch(&inner.client, &req, request_timeout).await;
     inner.last_used = Instant::now();
     inner.fetch_count = inner.fetch_count.saturating_add(1);
     drop(inner);
@@ -112,11 +96,4 @@ fn domain_of(url: &str) -> Result<String, AppError> {
     let parsed =
         url::Url::parse(url).map_err(|e| AppError::BadRequest(format!("invalid url: {e}")))?;
     Ok(parsed.host_str().unwrap_or("").to_string())
-}
-
-fn referer_header(req: &FetchRequest) -> Option<String> {
-    req.headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("referer"))
-        .map(|(_, v)| v.clone())
 }

--- a/px-camoufox/src/infrastructure/camoufox_fetcher.rs
+++ b/px-camoufox/src/infrastructure/camoufox_fetcher.rs
@@ -45,7 +45,16 @@ async fn run_through_session(
     // referer header is still sent on the in-page `fetch` so the
     // upstream sees a plausible navigation chain — we just don't
     // actually navigate the browser to that URL.
-    let landing = origin_of(&req.url).unwrap_or_else(|_| req.url.clone());
+    //
+    // When PX_DIAGNOSE_LAND_DIRECT=1 is set, override that policy and
+    // navigate directly to the target URL so the operator can inspect
+    // what PX actually renders (e.g. a press-and-hold captcha widget).
+    let diagnose = std::env::var("PX_DIAGNOSE_LAND_DIRECT").ok().as_deref() == Some("1");
+    let landing = if diagnose {
+        req.url.clone()
+    } else {
+        origin_of(&req.url).unwrap_or_else(|_| req.url.clone())
+    };
     if !inner.warmed || inner.last_visited.as_deref() != Some(landing.as_str()) {
         if let Err(e) = navigate_with_wait(
             &inner.client,
@@ -66,6 +75,27 @@ async fn run_through_session(
     // lifetime so PerimeterX sees a coherent returning visitor across
     // every fetch in the same Camoufox process.
     let _ = humanize_for(&inner.client, Some(&session.user)).await;
+
+    // Diagnose mode: skip the in-page fetch and return whatever the
+    // current page rendered. Operator dumps this body to inspect the
+    // PX captcha widget DOM, click targets, iframe sources, etc.
+    if diagnose {
+        let html = inner
+            .client
+            .execute("return document.body.outerHTML;", vec![])
+            .await
+            .map_err(|e| AppError::InternalError(format!("dump html: {e}")))?;
+        let body = html.as_str().unwrap_or("").to_string();
+        inner.last_used = Instant::now();
+        inner.fetch_count = inner.fetch_count.saturating_add(1);
+        drop(inner);
+        return Ok(FetchResponse {
+            status: 200,
+            headers: Default::default(),
+            body,
+            duration_ms: started.elapsed().as_millis() as u64,
+        });
+    }
 
     let outcome = in_page_fetch(&inner.client, &req, request_timeout).await;
     inner.last_used = Instant::now();

--- a/px-camoufox/src/infrastructure/camoufox_pool.rs
+++ b/px-camoufox/src/infrastructure/camoufox_pool.rs
@@ -13,6 +13,7 @@ use tokio::time::sleep;
 
 use crate::infrastructure::proxy_pool::ProxyPool;
 use crate::infrastructure::session_pool::SessionPool;
+use crate::infrastructure::synthetic_user::SyntheticUserPool;
 
 pub struct CamoufoxPool {
     pub(crate) config: CamoufoxConfig,
@@ -37,11 +38,21 @@ impl CamoufoxPool {
                 "proxy rotation enabled for /v1/fetch sessions"
             );
         }
+        let user_pool_size = std::env::var("PX_SYNTHETIC_USERS")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(20);
+        let users = Arc::new(SyntheticUserPool::new(user_pool_size));
+        tracing::info!(
+            count = users.len(),
+            "synthetic user pool seeded for /v1/fetch sessions"
+        );
         let sessions = Arc::new(SessionPool::new(
             config.clone(),
             Duration::from_secs(300),
             max_per_domain,
             proxies,
+            users,
         ));
         Ok(Self {
             config,

--- a/px-camoufox/src/infrastructure/caps.rs
+++ b/px-camoufox/src/infrastructure/caps.rs
@@ -13,9 +13,34 @@ pub(crate) fn build_capabilities(
     proxy: Option<&str>,
 ) -> Map<String, Value> {
     let mut prefs = Map::new();
-    prefs.insert("intl.accept_languages".into(), json!(config.locale.clone()));
+    // Build a richer accept-language string when locale is regional
+    // (es-AR → "es-AR,es;q=0.9,en-US;q=0.7,en;q=0.5"). PerimeterX
+    // weights this against the IP geo; "en-US" only on an AR exit is a
+    // bot tell.
+    prefs.insert(
+        "intl.accept_languages".into(),
+        json!(accept_languages(&config.locale)),
+    );
+    prefs.insert("intl.locale.requested".into(), json!(config.locale.clone()));
+    prefs.insert(
+        "general.useragent.locale".into(),
+        json!(config.locale.clone()),
+    );
     prefs.insert("dom.webnotifications.enabled".into(), json!(false));
     prefs.insert("media.peerconnection.enabled".into(), json!(false));
+    // History / privacy posture of a typical user — keeps history,
+    // accepts third-party cookies (most PX-protected SPAs need them),
+    // disables DNT (DNT=1 is a small but real bot signal).
+    prefs.insert("privacy.donottrackheader.enabled".into(), json!(false));
+    prefs.insert("places.history.enabled".into(), json!(true));
+    prefs.insert("network.cookie.cookieBehavior".into(), json!(0));
+    // When using SOCKS, resolve hostnames through the proxy too — keeps
+    // DNS leaks off the operator's egress and matches the proxy's geo.
+    if let Some(proxy_url) = proxy
+        && proxy_url.starts_with("socks")
+    {
+        prefs.insert("network.proxy.socks_remote_dns".into(), json!(true));
+    }
 
     let mut firefox_options = Map::new();
     let mut args: Vec<String> = Vec::new();
@@ -33,12 +58,69 @@ pub(crate) fn build_capabilities(
     caps.insert("browserName".into(), json!("firefox"));
     caps.insert("moz:firefoxOptions".into(), Value::Object(firefox_options));
     if let Some(proxy_url) = proxy {
-        caps.insert(
-            "proxy".into(),
-            json!({ "proxyType": "manual", "httpProxy": proxy_url, "sslProxy": proxy_url }),
-        );
+        caps.insert("proxy".into(), build_proxy_capability(proxy_url));
     }
     caps
+}
+
+/// Translate a `scheme://[user:pass@]host:port` proxy URL into the W3C
+/// `proxy` capability geckodriver expects. SOCKS variants set
+/// `socksProxy` + `socksVersion`; everything else falls back to
+/// `httpProxy` / `sslProxy`. Auth in the URL is ignored at the
+/// capability layer — geckodriver/Firefox have no W3C field for proxy
+/// credentials; operators that need auth should front the upstream
+/// with a local unauth relay (gost, 3proxy, etc.).
+fn build_proxy_capability(proxy_url: &str) -> Value {
+    let stripped = proxy_url
+        .strip_prefix("socks5h://")
+        .or_else(|| proxy_url.strip_prefix("socks5://"))
+        .or_else(|| proxy_url.strip_prefix("socks4://"))
+        .or_else(|| proxy_url.strip_prefix("socks://"))
+        .map(|rest| (true, rest))
+        .or_else(|| {
+            proxy_url
+                .strip_prefix("http://")
+                .or_else(|| proxy_url.strip_prefix("https://"))
+                .map(|rest| (false, rest))
+        });
+    let (is_socks, host_port) = match stripped {
+        Some((s, rest)) => (s, drop_userinfo(rest)),
+        None => (false, drop_userinfo(proxy_url)),
+    };
+    if is_socks {
+        json!({
+            "proxyType": "manual",
+            "socksProxy": host_port,
+            "socksVersion": 5,
+        })
+    } else {
+        json!({
+            "proxyType": "manual",
+            "httpProxy": host_port,
+            "sslProxy": host_port,
+        })
+    }
+}
+
+fn drop_userinfo(rest: &str) -> String {
+    match rest.rsplit_once('@') {
+        Some((_userinfo, host_port)) => host_port.to_string(),
+        None => rest.to_string(),
+    }
+}
+
+/// Turn a single locale (`es-AR`) into a realistic browser
+/// `Accept-Language` chain. Falls back to the raw locale when we don't
+/// have a known regional mapping.
+fn accept_languages(locale: &str) -> String {
+    match locale {
+        "es-AR" => "es-AR,es;q=0.9,en-US;q=0.7,en;q=0.5".into(),
+        "es-MX" => "es-MX,es;q=0.9,en-US;q=0.7,en;q=0.5".into(),
+        "es-ES" => "es-ES,es;q=0.9,en-US;q=0.7,en;q=0.5".into(),
+        "pt-BR" => "pt-BR,pt;q=0.9,en-US;q=0.7,en;q=0.5".into(),
+        "en-US" => "en-US,en;q=0.9".into(),
+        other => other.into(),
+    }
 }
 
 pub(crate) async fn pick_free_port() -> Result<u16, AppError> {

--- a/px-camoufox/src/infrastructure/fetch_strategies.rs
+++ b/px-camoufox/src/infrastructure/fetch_strategies.rs
@@ -21,37 +21,6 @@ use tokio::time::sleep;
 
 pub(crate) type FetchTriple = (u16, HashMap<String, String>, String);
 
-pub(crate) async fn navigate_and_read(
-    client: &fantoccini::Client,
-    req: &FetchRequest,
-    navigate_timeout: Duration,
-) -> Result<FetchTriple, AppError> {
-    // Warm session has CF clearance already; the new navigation only
-    // needs DOM to settle before we read body text. 1s is enough for
-    // the niles JSON endpoint to render `document.body.innerText`.
-    navigate_with_wait(
-        client,
-        &req.url,
-        navigate_timeout,
-        Duration::from_millis(1_000),
-    )
-    .await?;
-    let body_val = client
-        .execute("return document.body.innerText;", vec![])
-        .await
-        .map_err(|e| AppError::InternalError(format!("read body: {e}")))?;
-    let body = body_val.as_str().unwrap_or("").to_string();
-    let trimmed = body.trim_start();
-    let status = if trimmed.starts_with('{') || trimmed.starts_with('[') {
-        200
-    } else if looks_like_challenge(&body) {
-        403
-    } else {
-        500
-    };
-    Ok((status, HashMap::new(), body))
-}
-
 pub(crate) async fn in_page_fetch(
     client: &fantoccini::Client,
     req: &FetchRequest,
@@ -86,14 +55,6 @@ pub(crate) async fn in_page_fetch(
     Ok((status, headers, body))
 }
 
-fn looks_like_challenge(body: &str) -> bool {
-    body.contains("__cf_chl")
-        || body.contains("Just a moment")
-        || body.contains("\"appId\":\"PXeT15wiaE\"")
-        || body.contains("tráfico inusual")
-        || body.contains("trafico inusual")
-}
-
 pub(crate) async fn navigate_with_wait(
     client: &fantoccini::Client,
     url: &str,
@@ -105,5 +66,80 @@ pub(crate) async fn navigate_with_wait(
         return Err(AppError::InternalError(format!("navigate timeout: {url}")));
     }
     sleep(settle).await;
+    Ok(())
+}
+
+/// Synthetic "human" signal pack injected before `in_page_fetch`.
+///
+/// PerimeterX scores the bare `navigate → fetch` sequence as automation
+/// (no scroll, no pointer, no idle dwell). This script:
+///
+/// * dispatches a handful of `mousemove` events along a curved path,
+/// * scrolls to a randomised midpoint and back,
+/// * seeds a couple of realistic-looking `localStorage`/`sessionStorage`
+///   keys that PX consults for cross-visit continuity signals,
+/// * sleeps a randomised 600-1400 ms so request rhythm has jitter.
+///
+/// The whole thing is best-effort — any error from `execute` is logged
+/// at debug and swallowed so the fetch still runs.
+/// Synthetic "human" signal pack injected before `in_page_fetch`.
+///
+/// Beyond the bare scroll/mouse jitter, this seeds the page with the
+/// kind of "lived-in browser" state PerimeterX scores positively: a
+/// long-running GA `_ga` cookie, a `_gid` and `_fbp`, a synthetic
+/// `peya:firstVisit` localStorage timestamp set to N days ago, and a
+/// realistic visit count. When `user` is `Some`, those values come
+/// from a `SyntheticUser`; otherwise random anonymous values are used.
+pub(crate) async fn humanize_for(
+    client: &fantoccini::Client,
+    user: Option<&crate::infrastructure::synthetic_user::SyntheticUser>,
+) -> Result<(), AppError> {
+    let ga = user.map(|u| u.ga_client_id.clone()).unwrap_or_default();
+    let gid = user.map(|u| u.gid.clone()).unwrap_or_default();
+    let fbp = user.map(|u| u.fbp.clone()).unwrap_or_default();
+    let first_visit_days = user.map(|u| u.first_visit_days_ago).unwrap_or(7);
+    let sessions = user.map(|u| u.session_count).unwrap_or(3);
+    let user_id = user.map(|u| u.id.clone()).unwrap_or_else(|| "anon".into());
+    let user_id_js = serde_json::to_string(&user_id).unwrap_or_else(|_| "\"anon\"".into());
+    let ga_js = serde_json::to_string(&ga).unwrap_or_else(|_| "\"\"".into());
+    let gid_js = serde_json::to_string(&gid).unwrap_or_else(|_| "\"\"".into());
+    let fbp_js = serde_json::to_string(&fbp).unwrap_or_else(|_| "\"\"".into());
+    let script = format!(
+        r#"
+        const cb = arguments[arguments.length - 1];
+        try {{
+          const rand = (min, max) => min + Math.random() * (max - min);
+          const w = window.innerWidth || 1280;
+          const h = window.innerHeight || 720;
+          for (let i = 0; i < 6; i++) {{
+            document.dispatchEvent(new MouseEvent('mousemove', {{
+              clientX: rand(40, w - 40),
+              clientY: rand(40, h - 40),
+              bubbles: true,
+            }}));
+          }}
+          window.scrollTo({{ top: rand(120, 480), behavior: 'instant' }});
+          setTimeout(() => window.scrollTo({{ top: rand(0, 200), behavior: 'instant' }}), 200);
+          try {{
+            const visitMs = Date.now() - {first_visit_days} * 86400000;
+            localStorage.setItem('peya:firstVisit', String(visitMs));
+            localStorage.setItem('peya:sessions', String({sessions}));
+            localStorage.setItem('peya:userTag', {user_id_js});
+            sessionStorage.setItem('peya:lastInteraction', String(Date.now()));
+            if ({ga_js}) document.cookie = '_ga=' + {ga_js} + '; path=/; max-age=63072000';
+            if ({gid_js}) document.cookie = '_gid=' + {gid_js} + '; path=/; max-age=86400';
+            if ({fbp_js}) document.cookie = '_fbp=' + {fbp_js} + '; path=/; max-age=7776000';
+          }} catch (e) {{ /* storage / cookie may be partitioned */ }}
+          setTimeout(cb, Math.floor(rand(600, 1400)));
+        }} catch (e) {{ cb(); }}
+        "#,
+    );
+    let exec = client.execute_async(&script, vec![]);
+    if tokio::time::timeout(Duration::from_secs(5), exec)
+        .await
+        .is_err()
+    {
+        tracing::debug!("humanize timeout (non-fatal)");
+    }
     Ok(())
 }

--- a/px-camoufox/src/infrastructure/mod.rs
+++ b/px-camoufox/src/infrastructure/mod.rs
@@ -6,3 +6,4 @@ pub mod fetch_strategies;
 pub mod proxy_pool;
 pub mod session;
 pub mod session_pool;
+pub mod synthetic_user;

--- a/px-camoufox/src/infrastructure/session.rs
+++ b/px-camoufox/src/infrastructure/session.rs
@@ -6,6 +6,7 @@
 
 use crate::domain::config::CamoufoxConfig;
 use crate::infrastructure::caps::{build_capabilities, pick_free_port, wait_for_geckodriver};
+use crate::infrastructure::synthetic_user::SyntheticUser;
 use fantoccini::ClientBuilder;
 use px_errors::AppError;
 use std::time::{Duration, Instant};
@@ -19,6 +20,7 @@ use tokio::sync::Mutex;
 pub(crate) struct PersistentSession {
     pub(crate) created_at: Instant,
     pub(crate) inner: Mutex<Inner>,
+    pub(crate) user: SyntheticUser,
 }
 
 pub(crate) struct Inner {
@@ -42,6 +44,7 @@ impl PersistentSession {
         config: &CamoufoxConfig,
         domain: &str,
         proxy: Option<&str>,
+        user: SyntheticUser,
     ) -> Result<Self, AppError> {
         let port = pick_free_port().await?;
         let child = Command::new(&config.geckodriver_bin)
@@ -55,17 +58,29 @@ impl PersistentSession {
             .spawn()
             .map_err(|e| AppError::InternalError(format!("spawn geckodriver: {e}")))?;
         wait_for_geckodriver(port, Duration::from_secs(15)).await?;
-        let caps = build_capabilities(config, proxy);
+        // Per-user override of the config-level locale: the synthetic
+        // user's locale beats the global PX_CAMOUFOX_LOCALE so each
+        // session carries the matching Accept-Language chain.
+        let mut user_config = config.clone();
+        user_config.locale = user.locale.clone();
+        let caps = build_capabilities(&user_config, proxy);
         let endpoint = format!("http://127.0.0.1:{port}");
         let client = ClientBuilder::native()
             .capabilities(caps)
             .connect(&endpoint)
             .await
             .map_err(|e| AppError::InternalError(format!("webdriver connect: {e}")))?;
+        // Resize to the user's viewport so the screen fingerprint
+        // varies per synthetic identity.
+        let (w, h) = user.viewport;
+        let _ = client.set_window_size(w, h).await;
         tracing::info!(
             domain = %domain,
             port,
             proxy = proxy.unwrap_or("direct"),
+            user = %user.id,
+            locale = %user.locale,
+            viewport = format!("{w}x{h}"),
             "persistent Camoufox session spawned"
         );
         Ok(Self {
@@ -78,6 +93,7 @@ impl PersistentSession {
                 warmed: false,
                 last_visited: None,
             }),
+            user,
         })
     }
 

--- a/px-camoufox/src/infrastructure/session_pool.rs
+++ b/px-camoufox/src/infrastructure/session_pool.rs
@@ -8,6 +8,7 @@
 use crate::domain::config::CamoufoxConfig;
 use crate::infrastructure::proxy_pool::ProxyPool;
 use crate::infrastructure::session::PersistentSession;
+use crate::infrastructure::synthetic_user::SyntheticUserPool;
 use px_errors::AppError;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -28,6 +29,7 @@ pub(crate) struct SessionPool {
     ttl: Duration,
     max_per_domain: usize,
     proxies: Arc<ProxyPool>,
+    users: Arc<SyntheticUserPool>,
 }
 
 impl SessionPool {
@@ -36,6 +38,7 @@ impl SessionPool {
         ttl: Duration,
         max_per_domain: usize,
         proxies: Arc<ProxyPool>,
+        users: Arc<SyntheticUserPool>,
     ) -> Self {
         Self {
             config,
@@ -43,6 +46,7 @@ impl SessionPool {
             ttl,
             max_per_domain: max_per_domain.max(1),
             proxies,
+            users,
         }
     }
 
@@ -70,8 +74,9 @@ impl SessionPool {
             }
         }
         let proxy = self.proxies.next();
+        let user = self.users.next();
         let fresh =
-            Arc::new(PersistentSession::spawn(&self.config, domain, proxy.as_deref()).await?);
+            Arc::new(PersistentSession::spawn(&self.config, domain, proxy.as_deref(), user).await?);
         let mut guard = self.domains.lock().await;
         let slot = guard
             .entry(domain.to_string())

--- a/px-camoufox/src/infrastructure/synthetic_user.rs
+++ b/px-camoufox/src/infrastructure/synthetic_user.rs
@@ -1,0 +1,141 @@
+//! Synthetic-user pool for Camoufox sessions.
+//!
+//! Each `PersistentSession` is bound to one `SyntheticUser` for its
+//! lifetime. The user carries the kind of "lived-in browser" signals
+//! that PerimeterX scores positively: long-running analytics IDs (GA,
+//! Facebook), prior pageview counters in `localStorage`, a stable
+//! viewport + locale that matches the egress IP geo.
+//!
+//! Fingerprints already vary per Camoufox process (canvas / WebGL /
+//! audio); what we add here is the *persistent* layer those engines
+//! don't synthesize: account-like cookies and storage that look like a
+//! returning visitor.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Clone, Debug)]
+pub(crate) struct SyntheticUser {
+    pub id: String,
+    pub locale: String,
+    /// Built once at construction so callers don't recompute it; not
+    /// currently injected into the caps (locale alone is enough for
+    /// the Accept-Language header today).
+    #[allow(dead_code)]
+    pub accept_languages: String,
+    pub viewport: (u32, u32),
+    /// Future use: pass into Firefox prefs once Camoufox supports a
+    /// timezone override beyond the OS default.
+    #[allow(dead_code)]
+    pub timezone: String,
+    pub ga_client_id: String,
+    pub gid: String,
+    pub fbp: String,
+    /// Days-ago this synthetic visitor "first visited" pedidosya.
+    pub first_visit_days_ago: u32,
+    /// Synthetic visit count (used to seed `peya:sessions` etc.).
+    pub session_count: u32,
+}
+
+impl SyntheticUser {
+    /// Build a deterministic-but-varied user from an index. Same index
+    /// always yields the same user so session reuse keeps the persona
+    /// stable across requests.
+    pub fn from_index(idx: usize) -> Self {
+        let viewports = [
+            (1280, 720),
+            (1366, 768),
+            (1440, 900),
+            (1536, 864),
+            (1600, 900),
+            (1920, 1080),
+        ];
+        let locales = ["es-AR", "es-AR", "es-AR", "es-AR", "es-MX", "es-AR"];
+        let timezones = [
+            "America/Argentina/Buenos_Aires",
+            "America/Argentina/Cordoba",
+            "America/Argentina/Mendoza",
+        ];
+        let v = viewports[idx % viewports.len()];
+        let locale = locales[idx % locales.len()].to_string();
+        let tz = timezones[idx % timezones.len()].to_string();
+        Self {
+            id: format!("syn-{idx:04}"),
+            locale: locale.clone(),
+            accept_languages: accept_language_chain(&locale),
+            viewport: v,
+            timezone: tz,
+            ga_client_id: format!(
+                "{}.{}",
+                100_000_000 + idx * 7919,
+                1_700_000_000 - idx as u64 * 86_400
+            ),
+            gid: format!(
+                "GA1.2.{}.{}",
+                1_000_000_000 + idx * 31,
+                1_750_000_000 - idx as u64 * 1024
+            ),
+            fbp: format!(
+                "fb.1.{}.{}",
+                1_700_000_000 - idx as u64 * 600,
+                idx * 314_159 % 999_999
+            ),
+            first_visit_days_ago: 3 + (idx as u32 % 27),
+            session_count: 2 + (idx as u32 % 18),
+        }
+    }
+}
+
+fn accept_language_chain(locale: &str) -> String {
+    match locale {
+        "es-AR" => "es-AR,es;q=0.9,en-US;q=0.7,en;q=0.5".into(),
+        "es-MX" => "es-MX,es;q=0.9,en-US;q=0.7,en;q=0.5".into(),
+        other => other.into(),
+    }
+}
+
+pub(crate) struct SyntheticUserPool {
+    users: Vec<SyntheticUser>,
+    cursor: AtomicUsize,
+}
+
+impl SyntheticUserPool {
+    pub fn new(size: usize) -> Self {
+        let size = size.max(1);
+        Self {
+            users: (0..size).map(SyntheticUser::from_index).collect(),
+            cursor: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn next(&self) -> SyntheticUser {
+        let idx = self.cursor.fetch_add(1, Ordering::Relaxed) % self.users.len();
+        self.users[idx].clone()
+    }
+
+    pub fn len(&self) -> usize {
+        self.users.len()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_from_index() {
+        let a = SyntheticUser::from_index(7);
+        let b = SyntheticUser::from_index(7);
+        assert_eq!(a.id, b.id);
+        assert_eq!(a.ga_client_id, b.ga_client_id);
+    }
+
+    #[test]
+    fn pool_round_robins() {
+        let pool = SyntheticUserPool::new(3);
+        let ids: Vec<_> = (0..6).map(|_| pool.next().id).collect();
+        assert_eq!(ids[0], ids[3]);
+        assert_eq!(ids[1], ids[4]);
+        assert_eq!(ids[2], ids[5]);
+    }
+}


### PR DESCRIPTION
## Summary
Three stealth layers stacked behind the existing persistent-session fetch path. Goal was to push past PerimeterX's behavioral challenge on `/v2/niles/...` so the downstream pedidosya scraper can hit its ≥40 req/min target. We didn't fully break PX, but everything below the behavioral CAPTCHA layer is now hardened in a single shippable change.

### 1. SOCKS5 caps in `build_capabilities`
- Accepts `socks5://[user:pass@]host:port` proxy URLs, emits the W3C `proxy` capability with `socksProxy` + `socksVersion=5`.
- URL auth is stripped at the capability layer (W3C has no proxy-auth field). Operators front authed upstreams with a local unauth relay (`gost`, `3proxy`).
- Turns on `network.proxy.socks_remote_dns` so DNS exits via the proxy instead of leaking on the host.

### 2. Locale awareness
- `PX_CAMOUFOX_LOCALE` env (default `en-US`) feeds a regional `Accept-Language` chain (`es-AR` → `"es-AR,es;q=0.9,en-US;q=0.7,en;q=0.5"`), `intl.locale.requested`, `general.useragent.locale`.
- Privacy posture nudged toward "lived-in browser": DNT off, history on, accept third-party cookies (most PX-protected SPAs need them).

### 3. `SyntheticUserPool`
- N (default 20, via `PX_SYNTHETIC_USERS`) deterministic synthetic identities, each bound to one `PersistentSession` for its lifetime.
- A user carries: id, locale (mostly es-AR), Accept-Language chain, viewport (one of 6 common sizes; applied via webdriver `set_window_size` at spawn), timezone (held for future Camoufox tz override), stable `_ga`/`_gid`/`_fbp` cookie values, `first_visit_days_ago`, `session_count`.
- `humanize_for` injects all of the above into `localStorage` + `document.cookie` on every fetch warmup, alongside random mouse-moves, scroll-to-midpoint, and a 600–1400 ms jitter between warmup and the in-page fetch.

### Fetcher hot-path rewire
- Always lands warmup on the bare origin. SPA pages (vendor menu, `/restaurantes`) are PX-captcha-gated for direct webdriver navigation even on clean residential IPs; the homepage is the one "soft" entry that passes. Caller's referer is still sent on the in-page fetch.
- Drops the GET-via-`navigate_and_read` branch. Every method routes through `in_page_fetch` (SPA-XHR mimicry). The strategy selector + the `looks_like_challenge` body sniff become dead and are removed.

## Live status against pedidosya
- ✅ `/v1/solve` to homepage via AR socks5 → **full 6-cookie bundle** (`_pxhd`, `cf_clearance`, `__cf_bm`, `_pxvid`, `_px3`, `pxcts`). px-solver core works.
- ❌ `/v1/fetch` to `/v2/niles/.../menus` via AR + synthetic user + humanize → still serves PX's `px-captcha` HTML. PerimeterX gates that endpoint behaviorally beyond what fingerprint stealth alone can spoof.
- Remaining paths to 40 req/min (out of scope here): full SPA-driven XHR interception, or paid CAPTCHA-solver integration (2captcha / CapMonster).

## Configuration knobs
| Env | Default | What it does |
|---|---|---|
| `PX_PROXIES` | empty | CSV of proxy URLs (from PR #9) |
| `PX_FETCH_MAX_PER_DOMAIN` | 2 | Warm browsers per domain (from PR #8) |
| `PX_CAMOUFOX_LOCALE` | `en-US` | This PR |
| `PX_SYNTHETIC_USERS` | 20 | This PR |

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` against lefthook ruleset
- [x] `cargo test --workspace --no-fail-fast` — existing tests pass plus 2 new unit tests for `SyntheticUserPool` (determinism, round-robin)
- [x] Lefthook pre-commit + pre-push hooks pass
- [x] Live AR proxy sanity check: solve still returns 6 cookies; fetch still hits PX-captcha (call documented in PR body)
- [x] All new files under the 200-LOC axum-best-practice rule
- [x] `graphify-out/` added to `.gitignore`

## Follow-ups
- SPA-driven XHR interception path (drive Camoufox to vendor page, hook XHRs)
- 2captcha integration for px-captcha
- Per-proxy health tracking + skip-broken-proxy in `ProxyPool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)