### PR TITLE
chore: bump to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "px-cli"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "px-server"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-auth"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-cache"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-camoufox"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "fantoccini",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-captcha"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "pxsolver-errors",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-cloudflare"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "pxsolver-core",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-core"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "serde",
  "uuid",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-datadome"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "pxsolver-errors",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-detector"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "pxsolver-core",
  "regex",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-errors"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "axum",
  "serde",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-harvester"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "chromiumoxide",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-native"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "pxsolver-core",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-perimeterx"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "pxsolver-core",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-pipeline"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "pxsolver-core",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-turnstile"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "pxsolver-errors",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-types"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-validation"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "axum",
  "pxsolver-errors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "1.6.0"
+version       = "1.7.0"
 edition       = "2024"
 rust-version  = "1.95"
 license       = "AGPL-3.0-or-later"


### PR DESCRIPTION
Releases the R-track + native sensor synthesis work merged in #10, #11, and #13:

- **R2 decoder + R3 sensor RE** (PR #13) — 1 457 strings inlined, vP cipher stack reversed.
- **ADR-0024** activates native synthesis, supersedes ADR-0010.
- **N1-N5** — `px-native` cipher core, encryptor wrapper, event collector, `SensorNativeSolver`, TOML tenant profile.
- **Stealth hardening** (PR #10) — synthetic-user pool, humanize hooks, SOCKS5 auth-relay caps.

121 workspace tests pass, clippy clean under the unwrap/expect/panic ban, all files ≤200 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)