### PR TITLE
chore: bump to 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "px-cli"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "px-server"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-auth"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-cache"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-camoufox"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "fantoccini",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-captcha"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "pxsolver-errors",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-cloudflare"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "pxsolver-core",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-core"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "serde",
  "uuid",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-datadome"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "pxsolver-errors",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-detector"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "pxsolver-core",
  "regex",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-errors"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "axum",
  "serde",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-harvester"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "chromiumoxide",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-native"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-perimeterx"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "pxsolver-core",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-pipeline"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "pxsolver-core",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-turnstile"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "pxsolver-errors",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-types"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "pxsolver-validation"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "axum",
  "pxsolver-errors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "1.7.0"
+version       = "1.8.0"
 edition       = "2024"
 rust-version  = "1.95"
 license       = "AGPL-3.0-or-later"


### PR DESCRIPTION
Releases v1.8.0 — the native-bypass wiring + capture/calibrate/soak harness.

Merged this release cycle:
- #15 — `feat(server): wire SensorNativeSolver into solve dispatcher` (P1)
- #16 — `feat: XHR-hook captures + calibrate command` (P2 + P3)
- #17 — `feat(native): throughput soak + operator runbook` (P4)

Live validation (the bet itself) belongs to the operator — see `docs/runbook-native-bypass.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)